### PR TITLE
Add CORS headers when origin is supplied

### DIFF
--- a/sequins.go
+++ b/sequins.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/stripe/sequins/backend"
-	"github.com/stripe/sequins/index"
 	"log"
 	"net/http"
 	"os"
@@ -11,6 +9,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/stripe/sequins/backend"
+	"github.com/stripe/sequins/index"
 )
 
 type sequinsOptions struct {
@@ -116,6 +117,13 @@ func (s *sequins) refresh() error {
 }
 
 func (s *sequins) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if origin := r.Header.Get("Origin"); origin != "" {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS, HEAD")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token")
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+	}
+
 	if r.URL.Path == "/" {
 		count, err := s.index.Count()
 		if err != nil {

--- a/sequins_test.go
+++ b/sequins_test.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/stripe/sequins/backend"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stripe/sequins/backend"
 )
 
 func getSequins(t *testing.T, opts sequinsOptions) *sequins {
@@ -61,4 +62,15 @@ func TestSequinsNoValidDirectories(t *testing.T) {
 	s := newSequins(backend, sequinsOptions{"test_data/0", false})
 	err := s.start("localhost:0")
 	assert.Error(t, err)
+}
+
+func TestSequinsCors(t *testing.T) {
+	ts := getSequins(t, sequinsOptions{"test_data", false})
+
+	req, _ := http.NewRequest("GET", "/Alice", nil)
+	req.Header.Add("Origin", "something.org")
+	w := httptest.NewRecorder()
+	ts.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, []string{"something.org"}, w.HeaderMap["Access-Control-Allow-Origin"])
 }


### PR DESCRIPTION
Adds a reasonable (not wide-open) set of CORS headers when an Origin header is set.

r @colinmarc ?
