### PR TITLE
Add the ability to save and read manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 sequins
 testdata
+.index
+.manifest

--- a/hdfs_sequins_test.go
+++ b/hdfs_sequins_test.go
@@ -3,8 +3,8 @@ package main
 import (
 	"encoding/json"
 	"github.com/colinmarc/hdfs"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stripe/sequins/backend"
 	"io/ioutil"
 	"net/http"

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -3,16 +3,15 @@ package index
 import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"os"
 	"testing"
 )
 
-func TestDB(t *testing.T) {
+func TestIndex(t *testing.T) {
+	os.Remove("../test_data/0/.manifest")
 	index := New("../test_data/0")
-	err := index.BuildIndex()
-	require.Nil(t, err)
-	if err != nil {
-		t.FailNow()
-	}
+	err := index.Load()
+	require.NoError(t, err)
 
 	assert.Equal(t, index.Path, "../test_data/0")
 	assert.Equal(t, len(index.files), 2)
@@ -20,13 +19,33 @@ func TestDB(t *testing.T) {
 	assert.Equal(t, index.files[1].file.Name(), "../test_data/0/part-00001")
 
 	val, err := index.Get("Alice")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, string(val), "Practice")
 
 	val, err = index.Get("foo")
 	assert.Equal(t, ErrNotFound, err)
 
 	count, err := index.Count()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 3, count)
+}
+
+func TestIndexManifest(t *testing.T) {
+	os.Remove("../test_data/0/.manifest")
+	index := New("../test_data/0")
+	err := index.Load()
+	require.NoError(t, err)
+
+	count, err := index.Count()
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+
+	index.Close()
+	index = New("../test_data/0")
+	err = index.Load()
+	require.NoError(t, err)
+
+	newCount, err := index.Count()
+	require.NoError(t, err)
+	assert.Equal(t, count, newCount)
 }

--- a/index/manifest.go
+++ b/index/manifest.go
@@ -1,0 +1,51 @@
+package index
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+)
+
+type manifest struct {
+	Files []manifestEntry `json:"files"`
+	Count int             `json:"count"`
+}
+
+type manifestEntry struct {
+	Name string `json:"name"`
+	Size int64  `json:"size"`
+}
+
+func readManifest(path string) (manifest, error) {
+	m := manifest{}
+
+	reader, err := os.Open(path)
+	if err != nil {
+		return m, err
+	}
+
+	defer reader.Close()
+	bytes, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return m, err
+	}
+
+	err = json.Unmarshal(bytes, &m)
+	return m, err
+}
+
+func writeManifest(path string, m manifest) error {
+	bytes, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+
+	writer, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+
+	defer writer.Close()
+	_, err = writer.Write(bytes)
+	return err
+}

--- a/index/manifest.go
+++ b/index/manifest.go
@@ -2,6 +2,8 @@ package index
 
 import (
 	"encoding/json"
+	"hash/crc32"
+	"io"
 	"io/ioutil"
 	"os"
 )
@@ -13,7 +15,7 @@ type manifest struct {
 
 type manifestEntry struct {
 	Name string `json:"name"`
-	Size int64  `json:"size"`
+	CRC  uint32 `json:"crc"`
 }
 
 func readManifest(path string) (manifest, error) {
@@ -48,4 +50,19 @@ func writeManifest(path string, m manifest) error {
 	defer writer.Close()
 	_, err = writer.Write(bytes)
 	return err
+}
+
+func fileCrc(path string) (uint32, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+
+	hash := crc32.NewIEEE()
+	_, err = io.Copy(hash, file)
+	if err != nil {
+		return 0, err
+	}
+
+	return hash.Sum32(), nil
 }

--- a/sequins.go
+++ b/sequins.go
@@ -91,23 +91,23 @@ func (s *sequins) refresh() error {
 		}
 
 		if os.IsExist(err) {
-			log.Printf("Version %s is already downloaded.", version)
+			log.Printf("Version %s is already downloaded", version)
 		} else {
-			log.Printf("Downloading version %s from %s.", version, s.backend.DisplayPath(version))
+			log.Printf("Downloading version %s from %s", version, s.backend.DisplayPath(version))
 			err = s.backend.Download(version, path)
 			if err != nil {
 				return err
 			}
 		}
 
-		log.Printf("Building index over version %s at %s.", version, path)
+		log.Printf("Preparing version %s at %s", version, path)
 		index := index.New(path)
-		err = index.BuildIndex()
+		err = index.Load()
 		if err != nil {
 			return fmt.Errorf("Error while indexing: %s", err)
 		}
 
-		log.Println("Switching to new version!")
+		log.Printf("Switching to version %s!", version)
 		oldIndex := s.index
 		s.currentVersion = version
 		s.index = index

--- a/sequins_test.go
+++ b/sequins_test.go
@@ -3,14 +3,18 @@ package main
 import (
 	"encoding/json"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stripe/sequins/backend"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 )
 
 func getSequins(t *testing.T, opts sequinsOptions) *sequins {
+	os.RemoveAll("test_data/0/.manifest")
+	os.RemoveAll("test_data/1/.manifest")
 	backend := backend.NewLocalBackend("test_data")
 	s := newSequins(backend, opts)
 
@@ -50,7 +54,7 @@ func TestSequins(t *testing.T) {
 	status := &status{}
 	err := json.Unmarshal(w.Body.Bytes(), status)
 	require.NoError(t, err)
-	assert.Equal(t, 200, w.Code, 200)
+	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, "test_data/1", status.Path)
 	assert.True(t, status.Started >= now)
 	assert.Equal(t, 3, status.Count)


### PR DESCRIPTION
When building an index, save a json file with the expected files and sizes. If
the manifest exists when we start up sequins again, load it and use the
existing index rather than building a brand new index.

r? @jpellerin 