### PR TITLE
Fix race condition when upgrading between DB versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ sequins
 testdata
 .index
 .manifest
+*.swp
+test_scratch

--- a/hdfs_sequins_test.go
+++ b/hdfs_sequins_test.go
@@ -37,14 +37,7 @@ func getHdfsSequins(t *testing.T) *sequins {
 	tmpDir, _ := ioutil.TempDir("", "sequins-")
 	s := newSequins(backend, sequinsOptions{tmpDir, false})
 
-	go func() {
-		err := s.start("localhost:0")
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
-
-	time.Sleep(100 * time.Millisecond)
+	require.NoError(t, s.init())
 	return s
 }
 

--- a/index/index.go
+++ b/index/index.go
@@ -23,21 +23,25 @@ type indexFile struct {
 }
 
 type Index struct {
-	Path  string
-	Ready bool
+	Path    string
+	Ready   bool
+	Version string
 
 	files     []indexFile
 	readLocks []sync.Mutex
 
 	ldb   *leveldb.DB
 	count int
+
+	refcount sync.WaitGroup
 }
 
 // New creates a new Index instance.
-func New(path string) *Index {
+func New(path, version string) *Index {
 	index := Index{
-		Path:  path,
-		Ready: false,
+		Path:    path,
+		Ready:   false,
+		Version: version,
 	}
 
 	return &index

--- a/index/index_reference.go
+++ b/index/index_reference.go
@@ -1,0 +1,59 @@
+package index
+
+// helpers to atomically switch from using one index to another
+
+import (
+	"sync"
+)
+
+// IndexReference can be used to safely acquire, release, and upgrade indices
+type IndexReference struct {
+	rwMutex sync.RWMutex
+	index   *Index
+}
+
+// Get atomically acquires a reference to an index, and increments the refcount
+// the index will not be closed until the reference is released.
+func (im *IndexReference) Get() *Index {
+	im.rwMutex.RLock()
+	defer im.rwMutex.RUnlock()
+	index := im.index
+	if index != nil {
+		index.refcount.Add(1)
+	}
+
+	return index
+}
+
+// Release decrements the refcount for an index
+// Sequins may close the index after this point, if no other requests
+// hold a reference to it.
+func (im *IndexReference) Release(index *Index) {
+	if index != nil {
+		index.refcount.Done()
+	}
+}
+
+// UnsafeGet returns an index reference without doing any kind of locking or refcounts.
+// This is only safe to use when you only care about the index object in memory,
+// not the underlying index on disk that it represents. For example, you can
+// safely use this reference to find the version of the index.
+func (im *IndexReference) UnsafeGet() *Index {
+	return im.index
+}
+
+// Replace replaces the current index with a new one, waits for the old one to no longer
+// be in use, then returns.
+// At that point, no more requests are using the index, and it should be safe to close / destroy
+func (im *IndexReference) Replace(newIndex *Index) (oldIndex *Index) {
+	im.rwMutex.Lock()
+	oldIndex = im.index
+	im.index = newIndex
+	im.rwMutex.Unlock()
+
+	if oldIndex != nil {
+		oldIndex.refcount.Wait()
+	}
+
+	return oldIndex
+}

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestIndex(t *testing.T) {
 	os.Remove("../test_data/0/.manifest")
-	index := New("../test_data/0")
+	index := New("../test_data/0", "0")
 	err := index.Load()
 	require.NoError(t, err)
 
@@ -32,7 +32,7 @@ func TestIndex(t *testing.T) {
 
 func TestIndexManifest(t *testing.T) {
 	os.Remove("../test_data/0/.manifest")
-	index := New("../test_data/0")
+	index := New("../test_data/0", "0")
 	err := index.Load()
 	require.NoError(t, err)
 
@@ -41,7 +41,7 @@ func TestIndexManifest(t *testing.T) {
 	assert.Equal(t, 3, count)
 
 	index.Close()
-	index = New("../test_data/0")
+	index = New("../test_data/0", "0")
 	err = index.Load()
 	require.NoError(t, err)
 

--- a/main.go
+++ b/main.go
@@ -92,6 +92,11 @@ func main() {
 		s = hdfsSetup(parsed.Host, parsed.Path, opts)
 	}
 
+	err = s.init()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	go func() {
 		log.Fatal(s.start(*address))
 	}()

--- a/s3_sequins_test.go
+++ b/s3_sequins_test.go
@@ -46,12 +46,7 @@ func getS3Sequins(t *testing.T) *sequins {
 	tmpDir, _ := ioutil.TempDir("", "sequins-")
 	s := newSequins(backend, sequinsOptions{tmpDir, false})
 
-	go func() {
-		err := s.start("localhost:0")
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
+	require.NoError(t, s.init())
 
 	time.Sleep(100 * time.Millisecond)
 	return s

--- a/sequins_test.go
+++ b/sequins_test.go
@@ -2,12 +2,18 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stripe/sequins/backend"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -18,14 +24,7 @@ func getSequins(t *testing.T, opts sequinsOptions) *sequins {
 	backend := backend.NewLocalBackend("test_data")
 	s := newSequins(backend, opts)
 
-	go func() {
-		err := s.start("localhost:0")
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
-
-	time.Sleep(100 * time.Millisecond)
+	require.NoError(t, s.init())
 	return s
 }
 
@@ -63,6 +62,108 @@ func TestSequins(t *testing.T) {
 func TestSequinsNoValidDirectories(t *testing.T) {
 	backend := backend.NewLocalBackend("test_data/0")
 	s := newSequins(backend, sequinsOptions{"test_data/0", false})
-	err := s.start("localhost:0")
+	err := s.init()
 	assert.Error(t, err)
+}
+
+// TestSequinsThreadsafe makes sure that reads that occur during an update DTRT
+func TestSequinsThreadsafe(t *testing.T) {
+	scratch, err := ioutil.TempDir("", "sequins-")
+	require.NoError(t, err)
+	createTestIndex(t, scratch, 0)
+	ts := newSequins(backend.NewLocalBackend(scratch), sequinsOptions{scratch, false})
+	require.NoError(t, ts.init())
+
+	var wg sync.WaitGroup
+	threads := 50
+	wg.Add(threads)
+	for i := 0; i < threads; i++ {
+		go func() {
+			for j := 0; j < 1000; j++ {
+				req, err := http.NewRequest("GET", "/Alice", nil)
+				assert.NoError(t, err)
+
+				w := httptest.NewRecorder()
+				ts.ServeHTTP(w, req)
+
+				if w.Code != 200 && w.Code != 404 {
+					// we might get either response, depending on which version of the db we see
+					// we just want to make sure that we don't 500 (or anything else)
+					t.Errorf("Got error response when making a request (status=%d)", w.Code)
+				}
+			}
+			wg.Done()
+		}()
+	}
+
+	for i := 1; i < 100; i++ {
+		createTestIndex(t, scratch, i)
+		ts.reloadLatest()
+	}
+	wg.Wait()
+	require.NoError(t, os.RemoveAll(scratch))
+}
+
+func directoryCopy(t *testing.T, dest, src string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		// Swallow errors, since sometimes other jobs will clean up the .manifest partway through
+		// the directory copy, which causes errors
+		if err != nil {
+			return nil
+		} else if strings.HasPrefix(filepath.Base(path), ".") {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		} else if info.IsDir() {
+			return nil
+		}
+
+		reldir, err := filepath.Rel(src, filepath.Dir(path))
+		require.NoError(t, err)
+		if err != nil {
+			return err
+		}
+
+		err = os.MkdirAll(filepath.Join(dest, reldir), 0755)
+		require.NoError(t, err)
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(src, path)
+		require.NoError(t, err)
+		if err != nil {
+			return err
+		}
+
+		destfilename := filepath.Join(dest, rel)
+		t.Logf("Copying %s -> %s\n", path, destfilename)
+
+		srcfile, err := os.Open(path)
+		require.NoError(t, err)
+		if err != nil {
+			return err
+		}
+		defer srcfile.Close()
+
+		destfile, err := os.Create(destfilename)
+		require.NoError(t, err)
+		if err != nil {
+			return err
+		}
+		defer destfile.Close()
+
+		_, err = io.Copy(destfile, srcfile)
+		require.NoError(t, err)
+		return err
+	})
+}
+
+func createTestIndex(t *testing.T, scratch string, i int) {
+	t.Logf("Creating test version %d\n", i)
+	path := fmt.Sprintf("%s/%d", scratch, i)
+	src := fmt.Sprintf("test_data/%d/", i%2)
+
+	require.NoError(t, directoryCopy(t, path, src))
 }


### PR DESCRIPTION
Previously, we didn't do any synchronization on the index, so when we upgrade to a new index, the old one just gets stomped, even if there are requests that are currently using that index.

The strategy for fixing this is as follows: we take out an RW mutex when getting a reference to the index, and bump a refcount for that mutex. When updating to a new index version, the upgrader takes out a write lock on the mutex, swaps them, release the mutex, and then waits for the refcount of the mutex to drain to 0 before destroying it. This is reasonably efficient, since we only need mutual exclusion when getting _a reference to the index_, not when actually using it. The logic for this is mostly factored away in side of the newly created IndexMonitor struct.

r? @colinmarc 
