### PR TITLE
Fix bug in cleanup code

### DIFF
--- a/sequins.go
+++ b/sequins.go
@@ -65,7 +65,9 @@ func (s *sequins) start(address string) error {
 	// However, this may not be a problem, since you have to shift traffic to
 	// another instance before shutting down anyway, otherwise you'd have downtime
 
-	defer s.indexReference.Replace(nil).Close()
+	defer func() {
+		s.indexReference.Replace(nil).Close()
+	}()
 
 	log.Printf("Listening on %s", address)
 	return http.ListenAndServe(address, s)


### PR DESCRIPTION
Defer semantics are hard.
I missed that when you call `s.indexReference.Replace(nil).Close()`, the
`Close()` is deferred, but not the `Replace()`.
This resulted in immediately nilling the index upon starting up the http
server, which causes the server to panic.

r? @colinmarc 