### PR TITLE
Use temp dirs for downloads in progress (fixes #12)

### DIFF
--- a/backend/hdfs_backend.go
+++ b/backend/hdfs_backend.go
@@ -43,7 +43,7 @@ func (h *HdfsBackend) LatestVersion(checkForSuccess bool) (string, error) {
 	return "", fmt.Errorf("No valid versions at %s", h.displayURL(h.path))
 }
 
-func (h *HdfsBackend) Download(version string, destPath string) (rterr error) {
+func (h *HdfsBackend) Download(version string, destPath string) error {
 	versionPath := path.Join(h.path, version)
 	files, err := h.client.ReadDir(versionPath)
 	if err != nil {

--- a/backend/s3_backend.go
+++ b/backend/s3_backend.go
@@ -90,7 +90,7 @@ func (s *S3Backend) LatestVersion(checkForSuccess bool) (string, error) {
 	}
 }
 
-func (s *S3Backend) Download(version string, destPath string) (rterr error) {
+func (s *S3Backend) Download(version string, destPath string) error {
 	versionPrefix := path.Join(s.path, version)
 
 	// we'll assume large-ish files, and only download one at a time


### PR DESCRIPTION
This is not very DRY, but it passes existing tests. Any suggestions for cleaning it up a bit, or adding new tests to exercise the partial download protection? Is this approach to fixing #12 ok, or do you have a different idea of how to address it?