### PR TITLE
Remove NYTimes/gziphandler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ get-deps:
 	go get github.com/crowdmob/goamz/aws
 	go get github.com/stretchr/testify/assert
 	go get github.com/stretchr/testify/require
-	go get github.com/NYTimes/gziphandler
 
 clean:
 	rm -f sequins sequins-dump sequins-*.tar.gz

--- a/hdfs_sequins_test.go
+++ b/hdfs_sequins_test.go
@@ -56,25 +56,24 @@ func TestHdfsBackend(t *testing.T) {
 
 func TestHdfsSequins(t *testing.T) {
 	ts := getHdfsSequins(t)
-	h := ts.handler()
 
 	req, _ := http.NewRequest("GET", "/Alice", nil)
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, req)
+	ts.ServeHTTP(w, req)
 
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, "Practice", w.Body.String())
 
 	req, _ = http.NewRequest("GET", "/foo", nil)
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, req)
+	ts.ServeHTTP(w, req)
 
 	assert.Equal(t, 404, w.Code)
 	assert.Equal(t, "", w.Body.String())
 
 	req, _ = http.NewRequest("GET", "/", nil)
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, req)
+	ts.ServeHTTP(w, req)
 
 	now := time.Now().Unix() - 1
 	status := &status{}

--- a/s3_sequins_test.go
+++ b/s3_sequins_test.go
@@ -72,25 +72,24 @@ func TestS3Backend(t *testing.T) {
 
 func TestS3Sequins(t *testing.T) {
 	ts := getS3Sequins(t)
-	h := ts.handler()
 
 	req, _ := http.NewRequest("GET", "/Alice", nil)
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, req)
+	ts.ServeHTTP(w, req)
 
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, "Practice", w.Body.String())
 
 	req, _ = http.NewRequest("GET", "/foo", nil)
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, req)
+	ts.ServeHTTP(w, req)
 
 	assert.Equal(t, 404, w.Code)
 	assert.Equal(t, "", w.Body.String())
 
 	req, _ = http.NewRequest("GET", "/", nil)
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, req)
+	ts.ServeHTTP(w, req)
 
 	now := time.Now().Unix() - 1
 	status := &status{}

--- a/sequins.go
+++ b/sequins.go
@@ -14,8 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/NYTimes/gziphandler"
-
 	"github.com/stripe/sequins/backend"
 	"github.com/stripe/sequins/index"
 )
@@ -75,11 +73,7 @@ func (s *sequins) start(address string) error {
 	}()
 
 	log.Printf("Listening on %s", address)
-	return http.ListenAndServe(address, s.handler())
-}
-
-func (s *sequins) handler() http.Handler {
-	return gziphandler.GzipHandler(s)
+	return http.ListenAndServe(address, s)
 }
 
 func (s *sequins) reloadLatest() error {


### PR DESCRIPTION
The performance is pretty disappointing, and gzip is better handled
by standing up nginx in front anyway.