### PR TITLE
Add a 'throttle_loads' config property, and use it improve tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,9 @@ release: sequins sequins-dump
 	tar -cvzf $(RELEASE_NAME).tar.gz $(RELEASE_NAME)
 
 test: sequins
-	go test -v -race -timeout 30s $(shell go list ./... | grep -v vendor)
+	go test -short -race -timeout 30s $(shell go list ./... | grep -v vendor )
+	go test -timeout 10m -run "Cluster$$"
+
 
 clean:
 	rm -f sequins sequins-dump sequins-*.tar.gz

--- a/blocks/block_store_test.go
+++ b/blocks/block_store_test.go
@@ -24,7 +24,7 @@ func TestBlockStore(t *testing.T) {
 	err = sf.ReadHeader()
 	require.NoError(t, err, "reading the test file")
 
-	err = bs.AddFile(sf)
+	err = bs.AddFile(sf, 0)
 	require.NoError(t, err, "adding the file to the block store")
 
 	err = bs.Save()

--- a/config.go
+++ b/config.go
@@ -18,6 +18,7 @@ type sequinsConfig struct {
 	Root               string   `toml:"root"`
 	Bind               string   `toml:"bind"`
 	MaxParallelLoads   int      `toml:"max_parallel_loads"`
+	ThrottleLoads      duration `toml:"throttle_loads"`
 	LocalStore         string   `toml:"local_store"`
 	RefreshPeriod      duration `toml:"refresh_period"`
 	RequireSuccessFile bool     `toml:"require_success_file"`

--- a/sequins.conf.example
+++ b/sequins.conf.example
@@ -25,6 +25,13 @@ root = "hdfs://namenode:8020/path/to/sequins"
 # at a time, minimizing disk usage while new data is being loaded. If you set
 # this to 1, then loads will be completely serialized.
 
+# throttle_loads = "800μs"
+# Unset by default. If this flag is set, sequins will sleep this long between
+# writes while loading data, artificially slowing down loads and reducing disk
+# i/o. If you are using disks where the latency is extremely sensitive to
+# activity, then loading large amounts of data can negatively impact your
+# latency, and you may want to experiment with this setting.
+
 # refresh_period = "10m"
 # Unset by default. If this is specified, sequins will periodically download new
 # data this often (in seconds). If you enable this, you should also enable

--- a/version_builder.go
+++ b/version_builder.go
@@ -135,7 +135,7 @@ func (vsb *versionBuilder) addFile(bs *blocks.BlockStore, file string) error {
 		return fmt.Errorf("reading header from %s: %s", disp, err)
 	}
 
-	err = bs.AddFile(sf)
+	err = bs.AddFile(sf, vsb.sequins.config.ThrottleLoads.Duration)
 	if err == blocks.ErrWrongPartition {
 		log.Println("Skipping", disp, "because it contains no relevant partitions")
 	} else if err != nil {

--- a/zk_watcher_test.go
+++ b/zk_watcher_test.go
@@ -39,5 +39,7 @@ func connectZookeeperTest(t *testing.T) (*zkWatcher, *zk.TestCluster) {
 }
 
 func TestZKWatcher(t *testing.T) {
+	t.Skip() // TODO this test needs to be fleshed out
+
 	connectZookeeperTest(t)
 }


### PR DESCRIPTION
The functional cluster tests were sometimes failing because the client
doing HTTP gets sometimes wasn't fast enough to catch version changes
happening under the hood. Hooray for sequins being too fast!

I had thought before about allowing users to throttle loads, for
when they have small datasets and are super sensitive about latency.
It turns out this is a nice property to have when we're testing; we
can use it to slow down loads to an observable level.