### PR TITLE
Use the EC2 instance region if available

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,7 +115,8 @@ func s3Setup(bucketName string, path string, config sequinsConfig) *sequins {
 	metadata := ec2metadata.New(session.New())
 	regionName := config.S3.Region
 	if regionName == "" {
-		regionName, err := metadata.Region()
+		var err error
+		regionName, err = metadata.Region()
 		if regionName == "" || err != nil {
 			log.Fatal("Unspecified S3 region, and no instance region found.")
 		}


### PR DESCRIPTION
This fixes a bug where the EC2 instance region wasn't being correctly
picked up. The problem is that `regionName, err := metadata.Region()`
instantiates a new variable because of how `:=` works with lexical
scoping.