### PR TITLE
Implement staged proxying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 - sh vendor/github.com/colinmarc/hdfs/setup_test_env.sh
 before_script:
 - make
-script: make test
+script: make test test_functional
 before_deploy: make release
 deploy:
   provider: releases

--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,10 @@ status.tmpl.go: status.tmpl $(BUILD)/bin/go-bindata
 	$(BUILD)/bin/go-bindata -o status.tmpl.go status.tmpl
 
 sequins: $(SOURCES) status.tmpl.go $(BUILD)/lib/libsparkey.a $(BUILD)/lib/libsnappy.a $(BUILD)/lib/libzookeeper_mt.a
-	$(CGO_PREAMBLE) go build -x -ldflags "-X main.sequinsVersion=$(TRAVIS_TAG)"
+	$(CGO_PREAMBLE) go build -ldflags "-X main.sequinsVersion=$(TRAVIS_TAG)"
 
 sequins-dump: $(SOURCES)
-	go build -x -ldflags "-X main.sequinsVersion=$(TRAVIS_TAG)"  ./cmd/sequins-dump
+	go build -ldflags "-X main.sequinsVersion=$(TRAVIS_TAG)"  ./cmd/sequins-dump
 
 release: sequins sequins-dump
 	./sequins --version
@@ -66,8 +66,10 @@ release: sequins sequins-dump
 	cp sequins sequins-dump README.md LICENSE.txt $(RELEASE_NAME)/
 	tar -cvzf $(RELEASE_NAME).tar.gz $(RELEASE_NAME)
 
-test: sequins $(TEST_SOURCES)
-	$(CGO_PREAMBLE) go test -short -race -timeout 30s $(shell go list ./... | grep -v vendor ) -run TestZKWatcher
+test: $(TEST_SOURCES)
+	$(CGO_PREAMBLE) go test -short -race -timeout 30s $(shell go list ./... | grep -v vendor)
+
+test_functional: sequins $(TEST_SOURCES) test
 	$(CGO_PREAMBLE) go test -timeout 10m -run "^TestCluster"
 
 clean:
@@ -81,4 +83,4 @@ clean:
 	rm -f sequins sequins-dump sequins-*.tar.gz
 	rm -rf $(RELEASE_NAME)
 
-.PHONY: release test clean
+.PHONY: release test test_functional clean

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -110,10 +110,11 @@ func (tc *testCluster) addSequins() *testSequins {
 	config.Root = backendPath
 	config.LocalStore = path
 	config.RequireSuccessFile = true
+	config.Sharding.Enabled = true
+	config.Sharding.TimeToConverge = duration{100 * time.Millisecond}
+	config.Sharding.ProxyTimeout = duration{300 * time.Millisecond}
+	config.Sharding.AdvertisedHostname = "localhost"
 	config.ZK.Servers = []string{tc.zk.addr}
-	config.ZK.TimeToConverge = duration{100 * time.Millisecond}
-	config.ZK.ProxyTimeout = duration{300 * time.Millisecond}
-	config.ZK.AdvertisedHostname = "localhost"
 	config.Test.AllowLocalCluster = true
 
 	// Slow everything down to an observable level.

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -112,7 +112,7 @@ func (tc *testCluster) addSequins() *testSequins {
 	config.RequireSuccessFile = true
 	config.Sharding.Enabled = true
 	config.Sharding.TimeToConverge = duration{100 * time.Millisecond}
-	config.Sharding.ProxyTimeout = duration{300 * time.Millisecond}
+	config.Sharding.ProxyTimeout = duration{600 * time.Millisecond}
 	config.Sharding.AdvertisedHostname = "localhost"
 	config.ZK.Servers = []string{tc.zk.addr}
 	config.Test.AllowLocalCluster = true

--- a/config.go
+++ b/config.go
@@ -50,6 +50,7 @@ type shardingConfig struct {
 	Replication        int      `toml:"replication"`
 	TimeToConverge     duration `toml:"time_to_converge"`
 	ProxyTimeout       duration `toml:"proxy_timeout"`
+	ProxyStageTimeout  duration `toml:"proxy_stage_timeout"`
 	ClusterName        string   `toml:"cluster_name"`
 	AdvertisedHostname string   `toml:"advertised_hostname"`
 	ShardID            string   `toml:"shard_id"`
@@ -99,6 +100,7 @@ func defaultConfig() sequinsConfig {
 			Replication:        2,
 			TimeToConverge:     duration{10 * time.Second},
 			ProxyTimeout:       duration{100 * time.Millisecond},
+			ProxyStageTimeout:  duration{time.Duration(0)},
 			ClusterName:        "sequins",
 			AdvertisedHostname: "",
 			ShardID:            "",
@@ -153,6 +155,10 @@ func validateConfig(config sequinsConfig) (sequinsConfig, error) {
 	case blocks.SnappyCompression, blocks.NoCompression:
 	default:
 		return config, fmt.Errorf("Unrecognized compression option: %s", config.Storage.Compression)
+	}
+
+	if config.Sharding.Replication <= 0 {
+		return config, fmt.Errorf("Invalid replication factor: %d", config.Sharding.Replication)
 	}
 
 	return config, nil

--- a/config.go
+++ b/config.go
@@ -26,11 +26,12 @@ type sequinsConfig struct {
 	RequireSuccessFile bool     `toml:"require_success_file"`
 	ContentType        string   `toml:"content_type"`
 
-	Storage storageConfig `toml:"storage"`
-	S3      s3Config      `toml:"s3"`
-	ZK      zkConfig      `toml:"zk"`
-	Debug   debugConfig   `toml:"debug"`
-	Test    testConfig    `toml:"test"`
+	Storage  storageConfig  `toml:"storage"`
+	S3       s3Config       `toml:"s3"`
+	Sharding shardingConfig `toml:"sharding"`
+	ZK       zkConfig       `toml:"zk"`
+	Debug    debugConfig    `toml:"debug"`
+	Test     testConfig     `toml:"test"`
 }
 
 type storageConfig struct {
@@ -44,16 +45,20 @@ type s3Config struct {
 	SecretAccessKey string `toml:"secret_access_key"`
 }
 
-type zkConfig struct {
-	Servers            []string `toml:"servers"`
-	ConnectTimeout     duration `toml:"connect_timeout"`
-	SessionTimeout     duration `toml:"session_timeout"`
+type shardingConfig struct {
+	Enabled            bool     `toml:"enabled"`
 	Replication        int      `toml:"replication"`
 	TimeToConverge     duration `toml:"time_to_converge"`
 	ProxyTimeout       duration `toml:"proxy_timeout"`
 	ClusterName        string   `toml:"cluster_name"`
 	AdvertisedHostname string   `toml:"advertised_hostname"`
 	ShardID            string   `toml:"shard_id"`
+}
+
+type zkConfig struct {
+	Servers        []string `toml:"servers"`
+	ConnectTimeout duration `toml:"connect_timeout"`
+	SessionTimeout duration `toml:"session_timeout"`
 }
 
 type debugConfig struct {
@@ -89,16 +94,19 @@ func defaultConfig() sequinsConfig {
 			AccessKeyId:     "",
 			SecretAccessKey: "",
 		},
-		ZK: zkConfig{
-			Servers:            nil,
-			ConnectTimeout:     duration{1 * time.Second},
-			SessionTimeout:     duration{10 * time.Second},
+		Sharding: shardingConfig{
+			Enabled:            false,
 			Replication:        2,
 			TimeToConverge:     duration{10 * time.Second},
 			ProxyTimeout:       duration{100 * time.Millisecond},
 			ClusterName:        "sequins",
 			AdvertisedHostname: "",
 			ShardID:            "",
+		},
+		ZK: zkConfig{
+			Servers:        []string{"localhost:2181"},
+			ConnectTimeout: duration{1 * time.Second},
+			SessionTimeout: duration{10 * time.Second},
 		},
 		Debug: debugConfig{
 			Bind:    "",

--- a/debug.go
+++ b/debug.go
@@ -30,6 +30,7 @@ type sequinsStats struct {
 		status500 int64
 		status501 int64
 		status502 int64
+		status504 int64
 	}
 	Latency struct {
 		Max   float64
@@ -122,6 +123,7 @@ func (s *sequinsStats) updateRequestStats() {
 			s.Qps.status500 = 0
 			s.Qps.status501 = 0
 			s.Qps.status502 = 0
+			s.Qps.status504 = 0
 		case q := <-s.queries:
 			s.latencyHist.RecordValue(int64(q.duration / time.Microsecond))
 
@@ -139,6 +141,8 @@ func (s *sequinsStats) updateRequestStats() {
 				s.Qps.status501++
 			case 502:
 				s.Qps.status502++
+			case 504:
+				s.Qps.status504++
 			default:
 				log.Println("Untrackable http status:", q.status)
 			}
@@ -158,6 +162,7 @@ func (s *sequinsStats) snapshotRequestStats() {
 	s.Qps.ByStatus["500"] = s.Qps.status500
 	s.Qps.ByStatus["501"] = s.Qps.status501
 	s.Qps.ByStatus["502"] = s.Qps.status502
+	s.Qps.ByStatus["504"] = s.Qps.status504
 
 	ms := float64(1000)
 	s.Latency.Max = float64(s.latencyHist.Max()) / ms

--- a/main.go
+++ b/main.go
@@ -71,8 +71,8 @@ func main() {
 	var s *sequins
 	switch parsed.Scheme {
 	case "", "file":
-		if config.ZK.Servers != nil && !config.Test.AllowLocalCluster {
-			log.Fatal("You can't run sequins in distributed mode on local paths.")
+		if config.Sharding.Enabled && !config.Test.AllowLocalCluster {
+			log.Fatal("You can't run sequins with sharding enabled on local paths.")
 		}
 		s = localSetup(config.Root, config)
 	case "s3":

--- a/proxy.go
+++ b/proxy.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+type proxyResponse struct {
+	resp *http.Response
+	err  error
+}
+
+var errProxyTimeout = errors.New("all peers timed out")
+
+// proxyRequest proxies the request, trying each peer that should have the key
+// in turn. The total logical attempt will be capped at the configured proxy
+// timeout, but individual peers will be tried using the following algorithm:
+//   - Each interval of 'proxy_stage_timeout', starting immediately, a request
+//     is kicked off to one random not-yet-tried peer. All requests after
+//     the first run concurrently.
+//   - If a request finishes successfully to any peer, the result is returned
+//     immediately and the others are canceled, as long as the result was not
+//     an error.
+//   - If a request finishes, but resulted in an error, another is kicked off
+//     immediately to another random not-yet-tried peer.
+//   - This process continues until either all peers are being tried, in which
+//     case the code just waits for one to finish. If the total 'proxy_timeout'
+//     is hit at any point, the method returns immediately with an error and
+//     cancels any running requests.
+func (vs *version) proxyRequest(r *http.Request, peers []string) (*http.Response, error) {
+	responses := make(chan proxyResponse, len(peers))
+	cancel := make(chan struct{})
+	defer close(cancel)
+
+	peerIndex := 0
+	outstanding := 0
+	totalTimeout := time.NewTimer(vs.sequins.config.Sharding.ProxyTimeout.Duration)
+	for {
+		stageTimeout := time.NewTimer(vs.sequins.config.Sharding.ProxyStageTimeout.Duration)
+		if peerIndex < len(peers) {
+			url := fmt.Sprintf("http://%s%s?proxy=%s", peers[peerIndex], r.URL.Path, vs.name)
+			go vs.proxyAttempt(url, responses, cancel)
+			peerIndex += 1
+			outstanding += 1
+		} else if outstanding == 0 {
+			return nil, errNoAvailablePeers
+		}
+
+		select {
+		case res := <-responses:
+			if res.err != nil {
+				log.Printf("Error proxying request to peer: %s", res.err)
+				outstanding -= 1
+				continue
+			} else {
+				return res.resp, nil
+			}
+		case <-totalTimeout.C:
+			return nil, errProxyTimeout
+		case <-stageTimeout.C:
+		}
+	}
+
+	return nil, errNoAvailablePeers
+}
+
+func (vs *version) proxyAttempt(url string, res chan proxyResponse, cancel chan struct{}) {
+	// Create a fresh request, so we don't pass on any baggage like
+	// 'Connection: close' headers.
+	proxyRequest, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		res <- proxyResponse{nil, err}
+		return
+	}
+
+	proxyRequest.Cancel = cancel
+	resp, err := http.DefaultClient.Do(proxyRequest)
+	if err != nil {
+		res <- proxyResponse{nil, err}
+		return
+	}
+
+	if resp.StatusCode != 200 && resp.StatusCode != 404 {
+		resp.Body.Close()
+		res <- proxyResponse{nil, fmt.Errorf("got %d", resp.StatusCode)}
+		return
+	}
+
+	res <- proxyResponse{resp, nil}
+}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var proxyTestVersion = &version{
+	name: "foo",
+	sequins: &sequins{
+		config: sequinsConfig{
+			Sharding: shardingConfig{
+				ProxyTimeout:      duration{30 * time.Millisecond},
+				ProxyStageTimeout: duration{10 * time.Millisecond},
+			},
+		},
+	},
+}
+
+func httptestHost(s *httptest.Server) string {
+	parsed, _ := url.Parse(s.URL)
+	return parsed.Host
+}
+
+func TestProxySinglePeer(t *testing.T) {
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "all good")
+	}))
+
+	peers := []string{httptestHost(peer)}
+
+	r, _ := http.NewRequest("GET", "http://localhost", nil)
+	resp, err := proxyTestVersion.proxyRequest(r, peers)
+	assert.NoError(t, err, "simple proxying should work")
+	assert.NotNil(t, resp, "simple proxying should work")
+}
+
+func TestProxySlowPeer(t *testing.T) {
+	slowPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		fmt.Fprintln(w, "sorry, did you need something?")
+	}))
+
+	goodPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "all good")
+	}))
+
+	notReachedPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.FailNow(t, "proxying should succeed before getting to a third peer")
+	}))
+
+	peers := []string{httptestHost(slowPeer), httptestHost(goodPeer), httptestHost(notReachedPeer)}
+	r, _ := http.NewRequest("GET", "http://localhost", nil)
+	resp, err := proxyTestVersion.proxyRequest(r, peers)
+	require.NoError(t, err, "proxying should work on the second peer")
+	require.NotNil(t, resp, "proxying should work on the second peer")
+
+	b, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err, "reading proxied response")
+	assert.Equal(t, "all good\n", string(b))
+}
+
+func TestProxyErrorPeer(t *testing.T) {
+	errorPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+
+	goodPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "all good")
+	}))
+
+	notReachedPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(t, "proxying should succeed before getting to a third peer")
+	}))
+
+	peers := []string{httptestHost(errorPeer), httptestHost(goodPeer), httptestHost(notReachedPeer)}
+	r, _ := http.NewRequest("GET", "http://localhost", nil)
+	resp, err := proxyTestVersion.proxyRequest(r, peers)
+	require.NoError(t, err, "proxying should work on the second peer")
+	require.NotNil(t, resp, "proxying should work on the second peer")
+
+	b, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err, "reading proxied response")
+	assert.Equal(t, "all good\n", string(b))
+}
+
+func TestProxySlowPeerErrorPeer(t *testing.T) {
+	slowPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(15 * time.Millisecond)
+		fmt.Fprintln(w, "all good, sorry to keep you waiting")
+	}))
+
+	errorPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+
+	peers := []string{httptestHost(slowPeer), httptestHost(errorPeer)}
+	r, _ := http.NewRequest("GET", "http://localhost", nil)
+	resp, err := proxyTestVersion.proxyRequest(r, peers)
+	require.NoError(t, err, "proxying should work on the first peer")
+	require.NotNil(t, resp, "proxying should work on the first peer")
+
+	b, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err, "reading proxied response")
+	assert.Equal(t, "all good, sorry to keep you waiting\n", string(b))
+}
+
+func TestProxyTimeout(t *testing.T) {
+	slowPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		fmt.Fprintln(w, "sorry, did you need something?")
+	}))
+
+	notReachedPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail(t, "proxying should never try a fourth peer")
+	}))
+
+	peers := []string{
+		httptestHost(slowPeer),
+		httptestHost(slowPeer),
+		httptestHost(slowPeer),
+		httptestHost(notReachedPeer),
+	}
+
+	r, _ := http.NewRequest("GET", "http://localhost", nil)
+	resp, err := proxyTestVersion.proxyRequest(r, peers)
+	assert.Equal(t, errProxyTimeout, err, "proxying should time out with all slow peers")
+	assert.Nil(t, resp, "proxying should time out with all slow peers")
+}
+
+func TestProxyErrors(t *testing.T) {
+	errorPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+	}))
+
+	peers := []string{
+		httptestHost(errorPeer),
+		httptestHost(errorPeer),
+		httptestHost(errorPeer),
+	}
+
+	r, _ := http.NewRequest("GET", "http://localhost", nil)
+	resp, err := proxyTestVersion.proxyRequest(r, peers)
+	assert.Equal(t, errNoAvailablePeers, err, "proxying should return errNoAvailablePeers if all error")
+	assert.Nil(t, resp, "proxying should return errNoAvailablePeers if all error")
+}

--- a/sequins.conf.example
+++ b/sequins.conf.example
@@ -67,19 +67,12 @@ root = "hdfs://namenode:8020/path/to/sequins"
 # variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY will be used, or IAM
 # instance role credentials if they are available.
 
-[zk]
+[sharding]
 
-# servers = ["localhost:2181"]
-# Unset by default. If set, sequins will connect to zookeeper at the given
-# addresses and try to join the existing cluster.
-
-# connect_timeout = "1s"
-# This specifies how long to wait while connecting to zookeeper.
-
-# session_timeout = "10s"
-# This specifies the session timeout to use with zookeeper. The
-# actual timeout is negotiated between server and client, but will never be
-# lower than this number.
+# enabled = false
+# If true, sequins will attempt to connect to zookeeper at the specified
+# addresses (see below), and coordinate with peer instances to shard datasets.
+# For a complete description of the sharding algorithm, see the manual.
 
 # replication = 2
 # This is the number of replicas responsible for each partition.
@@ -112,6 +105,20 @@ root = "hdfs://namenode:8020/path/to/sequins"
 # the same  partitions. This can be useful if you don't have stable hostnames,
 # but want to be able to rebuild a server to take the place of a dead or
 # decomissioning one.
+
+[zk]
+
+# servers = ["localhost:2181"]
+# If set and 'sharding.enabled' is true, sequins will connect to zookeeper at
+# the given addresses.
+
+# connect_timeout = "1s"
+# This specifies how long to wait while connecting to zookeeper.
+
+# session_timeout = "10s"
+# This specifies the session timeout to use with zookeeper. The
+# actual timeout is negotiated between server and client, but will never be
+# lower than this number.
 
 [debug]
 

--- a/sequins.conf.example
+++ b/sequins.conf.example
@@ -87,6 +87,13 @@ root = "hdfs://namenode:8020/path/to/sequins"
 # particularly cold storage, or if there are other factors significantly
 # increasing request time.
 
+# proxy_stage_timeout = "50ms"
+# Unset by default. After this interval, sequins will try another peer
+# concurrently with the first, as long as there are other peers available and
+# the total time is less than 'proxy_timeout'. If left unset, this defaults to
+# the 'proxy_timeout' divided by 'replication_factor' - enough time for all
+# peers to be tried within the total timeout.
+
 # cluster_name = "sequins"
 # This defines the root prefix to use for zookeeper state. If you are running
 # multiple sequins clusters using the same zookeeper for coordination, you

--- a/status.go
+++ b/status.go
@@ -184,7 +184,7 @@ func (s *sequins) getPeerStatus(peer string, db string) (status, error) {
 		return status, err
 	}
 
-	resp, err := s.proxyClient.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return status, err
 	}

--- a/version.go
+++ b/version.go
@@ -22,8 +22,8 @@ var errNoAvailablePeers = errors.New("no available peers")
 var errProxiedIncorrectly = errors.New("this server doesn't have the requested partition")
 
 // A version represents a single version of a particular sequins db: in
-// other words, a collection of files. In the distributed case, it understands
-// partitions and can route requests.
+// other words, a collection of files. In the sharding-enabled case, it
+// understands distribution of partitions and can route requests.
 type version struct {
 	sequins *sequins
 
@@ -51,7 +51,7 @@ func newVersion(sequins *sequins, path, db, name string, numPartitions int) *ver
 	var local map[int]bool
 	if sequins.peers != nil {
 		vs.partitions = watchPartitions(sequins.zkWatcher, sequins.peers,
-			db, name, numPartitions, sequins.config.ZK.Replication)
+			db, name, numPartitions, sequins.config.Sharding.Replication)
 
 		local = vs.partitions.pickLocalPartitions()
 		vs.selectedLocalPartitions = local

--- a/version.go
+++ b/version.go
@@ -104,12 +104,17 @@ func (vs *version) advertiseAndWait() bool {
 
 // serveKey is the entrypoint for incoming HTTP requests.
 func (vs *version) serveKey(w http.ResponseWriter, r *http.Request, key string) {
-	res, err := vs.get(key, r)
+	res, err := vs.get(r, key)
 
 	if err == errNoAvailablePeers {
-		// All of our peers failed us. 502.
-		log.Printf("All peers failed to respond for /%s/%s (version %s)", vs.db, key, vs.name)
+		// Either something is wrong with sharding, or all peers errored for some
+		// other reason. 502
+		log.Printf("No peers available for /%s/%s (version %s)", vs.db, key, vs.name)
 		w.WriteHeader(http.StatusBadGateway)
+	} else if err == errProxyTimeout {
+		// All of our peers failed us. 504.
+		log.Printf("All peers timed out for /%s/%s (version %s)", vs.db, key, vs.name)
+		w.WriteHeader(http.StatusGatewayTimeout)
 	} else if err != nil {
 		// Some other error. 500.
 		log.Printf("Error fetching value for /%s/%s: %s\n", vs.db, key, err)
@@ -130,7 +135,7 @@ func (vs *version) serveKey(w http.ResponseWriter, r *http.Request, key string) 
 
 // get looks up a value locally, or, failing that, asks a peer that has it.
 // If the request was proxied, it is not proxied further.
-func (vs *version) get(key string, r *http.Request) ([]byte, error) {
+func (vs *version) get(r *http.Request, key string) ([]byte, error) {
 	if vs.numPartitions == 0 {
 		return nil, nil
 	}
@@ -140,10 +145,10 @@ func (vs *version) get(key string, r *http.Request) ([]byte, error) {
 	if bs != nil && vs.hasPartition(partition) || vs.hasPartition(alternatePartition) {
 		return bs.Get(key)
 	} else if r.URL.Query().Get("proxy") == "" {
-		res, err := vs.proxyRequest(partition, r)
+		res, err := vs.getPeers(r, partition)
 		if res == nil && err == nil && alternatePartition != partition {
 			log.Println("Trying alternate partition for pathological key", key)
-			res, err = vs.proxyRequest(alternatePartition, r)
+			res, err = vs.getPeers(r, alternatePartition)
 		}
 
 		return res, err
@@ -153,15 +158,11 @@ func (vs *version) get(key string, r *http.Request) ([]byte, error) {
 
 }
 
-// hasPartition returns true if we have the partition available locally.
-func (vs *version) hasPartition(partition int) bool {
-	return vs.getBlockStore() != nil && (vs.partitions == nil || vs.partitions.local[partition])
-}
-
-// proxyRequest proxies the request, trying each peer that should have the key
-// in turn.
-func (vs *version) proxyRequest(partition int, r *http.Request) ([]byte, error) {
+func (vs *version) getPeers(r *http.Request, partition int) ([]byte, error) {
 	peers := vs.partitions.getPeers(partition)
+	if len(peers) == 0 {
+		return nil, errNoAvailablePeers
+	}
 
 	// Shuffle the peers, so we try them in a random order.
 	// TODO: don't blacklist nodes, but we can weight them lower
@@ -171,29 +172,7 @@ func (vs *version) proxyRequest(partition int, r *http.Request) ([]byte, error) 
 		shuffled[v] = peers[i]
 	}
 
-	for _, peer := range shuffled {
-		res, err := vs.proxyAttempt(peer, r)
-		if err != nil {
-			log.Printf("Error proxying request to peer %s: %s", r.URL.String(), err)
-			continue
-		}
-
-		return res, nil
-	}
-
-	return nil, errNoAvailablePeers
-}
-
-func (vs *version) proxyAttempt(peer string, r *http.Request) ([]byte, error) {
-	r.URL.RawQuery = fmt.Sprintf("proxy=%s", vs.name)
-	r.URL.Scheme = "http"
-	r.URL.Host = peer
-	proxyRequest, err := http.NewRequest("GET", r.URL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := vs.sequins.proxyClient.Do(proxyRequest)
+	resp, err := vs.proxyRequest(r, peers)
 	if err != nil {
 		return nil, err
 	}
@@ -206,6 +185,11 @@ func (vs *version) proxyAttempt(peer string, r *http.Request) ([]byte, error) {
 	}
 
 	return ioutil.ReadAll(resp.Body)
+}
+
+// hasPartition returns true if we have the partition available locally.
+func (vs *version) hasPartition(partition int) bool {
+	return vs.getBlockStore() != nil && (vs.partitions == nil || vs.partitions.local[partition])
 }
 
 func (vs *version) close() {


### PR DESCRIPTION
This is an attempt to try and minimize variance in latency without increasing load, by introducing a technique in proxying that I'm sure has a real name, but which I'm calling staged proxying.

The basic idea is this. When we need to proxy a request, and have N peers which could service that request, we can try concurrent requests if the peer we try first is being particularly slow. We use the following algorithm to dispatch requests:

 - Each interval of `proxy_stage_timeout`, starting immediately, a request is kicked off to one random not-yet-tried peer. All requests after the first run concurrently.
 - If a request finishes successfully to any peer, the result is returned immediately and the others are canceled, as long as the result was not an error.
 - If a request finishes, but resulted in an error, another is kicked off immediately to another random not-yet-tried peer.
 - This process continues until either all peers are being tried, in which case the code just waits for one to finish. If the total `proxy_timeout` is hit at any point, the method returns immediately with an error and cancels any running requests.

That means we should be able to crank `proxy_stage_timeout` (btw, not in love with this name) all the way down to our observed p99 of a few ms, but keep the `proxy_timeout` high for the cases where we're actually in trouble but want to stay available. Which means that even if one node is behaving really badly, the max latency should never jump above twice the p99. 

In the worst case, where everything is slow, I don't believe this will increase load significantly, since we're actually changing the meaning of `proxy_timeout`. With the old behavior and a `proxy_timeout` of 100ms, we'd do three requests over 300ms, and now we'd do three requests over 100ms. So the requests would be less spread out, but it wouldn't actually increasing the actual number of requests made (and unless the cluster is only fubar for 100ms, that shouldn't make a difference anyway). I think. Please tell me if that sounds wrong.

There are also some config changes to support this. Since `proxy_timeout` now has a semantically different meaning, and I moved a few config properties around, this is a backwards incompatible change. So it's a good thing we haven't cut an RC yet. =)