### PR TITLE
Add some zkWatcher tests, and fix some minor bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ release: sequins sequins-dump
 	tar -cvzf $(RELEASE_NAME).tar.gz $(RELEASE_NAME)
 
 test: $(TEST_SOURCES)
-	$(CGO_PREAMBLE) go test -short -race -timeout 30s $(shell go list ./... | grep -v vendor)
+	$(CGO_PREAMBLE) go test -short -race -timeout 1m $(shell go list ./... | grep -v vendor)
 
 test_functional: sequins $(TEST_SOURCES) test
 	$(CGO_PREAMBLE) go test -timeout 10m -run "^TestCluster"

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -39,7 +39,7 @@ type testCluster struct {
 	binary     string
 	root       string
 	sequinses  []*testSequins
-	zk         testZK
+	zk         *testZK
 	testClient *http.Client
 }
 

--- a/zk_watcher.go
+++ b/zk_watcher.go
@@ -25,6 +25,7 @@ var defaultZkACL = zk.WorldACL(zk.PERM_ALL)
 // reconnects to zookeeper, and tries its best to be resilient to failures, but
 // defaults to silently not providing updates.
 type zkWatcher struct {
+	sync.RWMutex
 	zkServers      []string
 	connectTimeout time.Duration
 	sessionTimeout time.Duration
@@ -34,7 +35,6 @@ type zkWatcher struct {
 	shutdown       chan bool
 
 	hooksLock      sync.Mutex
-	reconnectLock  sync.RWMutex
 	ephemeralNodes map[string]bool
 	watchedNodes   map[string]watchedNode
 }
@@ -77,9 +77,9 @@ func (w *zkWatcher) reconnect() error {
 		}
 	}
 
+	w.Lock()
+
 	servers := strings.Join(w.zkServers, ",")
-	w.reconnectLock.Lock()
-	defer w.reconnectLock.Unlock()
 	log.Println("Connecting to zookeeper at", servers)
 	conn, events, err = zk.Dial(servers, w.sessionTimeout)
 	if err != nil {
@@ -100,6 +100,8 @@ func (w *zkWatcher) reconnect() error {
 			return fmt.Errorf("connection error: %s", event)
 		}
 	}
+
+	w.Unlock()
 
 	// TODO: recreate permanent paths? What if zookeeper dies and loses data?
 	// TODO: clear data on setup? or just hope that it's uniquely namespaced enough
@@ -221,12 +223,18 @@ func (w *zkWatcher) removeEphemeral(node string) {
 	w.hooksLock.Lock()
 	defer w.hooksLock.Unlock()
 
+	w.RLock()
+	defer w.RUnlock()
+
 	node = path.Join(w.prefix, node)
 	w.conn.Delete(node, -1)
 	delete(w.ephemeralNodes, node)
 }
 
 func (w *zkWatcher) hookCreateEphemeral(node string) error {
+	w.RLock()
+	defer w.RUnlock()
+
 	_, err := w.conn.Create(node, "", zk.EPHEMERAL, defaultZkACL)
 	if err != nil {
 		return err
@@ -269,6 +277,9 @@ func (w *zkWatcher) removeWatch(node string) {
 }
 
 func (w *zkWatcher) hookWatchChildren(node string, wn watchedNode) error {
+	w.RLock()
+	defer w.RUnlock()
+
 	children, _, events, err := w.conn.ChildrenW(node)
 	if err != nil {
 		return err
@@ -289,9 +300,9 @@ func (w *zkWatcher) hookWatchChildren(node string, wn watchedNode) error {
 				}
 			}
 
-			w.reconnectLock.RLock()
+			w.RLock()
 			children, _, events, err = w.conn.ChildrenW(node)
-			w.reconnectLock.RUnlock()
+			w.RUnlock()
 
 			if err != nil {
 				sendErr(w.errs, err)
@@ -306,6 +317,9 @@ func (w *zkWatcher) hookWatchChildren(node string, wn watchedNode) error {
 
 // createPath creates a node and all its parents permanently.
 func (w *zkWatcher) createPath(node string) error {
+	w.RLock()
+	defer w.RUnlock()
+
 	node = path.Join(w.prefix, node)
 	err := w.createAll(node)
 	if err != nil {
@@ -333,6 +347,9 @@ func (w *zkWatcher) createAll(fullNode string) error {
 }
 
 func (w *zkWatcher) close() {
+	w.Lock()
+	defer w.Unlock()
+
 	w.shutdown <- true
 	w.conn.Close()
 }

--- a/zk_watcher.go
+++ b/zk_watcher.go
@@ -112,7 +112,7 @@ func (w *zkWatcher) reconnect() error {
 
 	go func() {
 		for ev := range events {
-			if !ev.Ok() {
+			if ev.State != zk.STATE_CONNECTED && ev.State != zk.STATE_CONNECTING {
 				sendErr(w.errs, errors.New(ev.String()))
 				return
 			}

--- a/zk_watcher_test.go
+++ b/zk_watcher_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	zk "launchpad.net/gozk/zookeeper"
 )
 
@@ -21,19 +21,35 @@ func randomPort() int {
 
 type testZK struct {
 	*testing.T
+	port int
+	home string
 	dir  string
 	addr string
 	zk   *zk.Server
 }
 
-func (zk testZK) printLogs() {
-	log, _ := ioutil.ReadFile(filepath.Join(zk.dir, "log.txt"))
-	zk.T.Logf("===== ZOOKEEPER LOGS:\n%s", log)
+func (tzk testZK) printLogs() {
+	log, _ := ioutil.ReadFile(filepath.Join(tzk.dir, "log.txt"))
+	tzk.T.Logf("===== ZOOKEEPER LOGS:\n%s", log)
 }
 
-func (zk testZK) close() {
-	zk.printLogs()
-	zk.zk.Destroy()
+func (tzk testZK) restart() {
+	tzk.close()
+	time.Sleep(time.Second)
+
+	zk, err := zk.CreateServer(tzk.port, tzk.dir, tzk.home)
+	require.NoError(tzk.T, err, "zk restart")
+
+	err = zk.Start()
+	require.NoError(tzk.T, err, "zk restart")
+	time.Sleep(time.Second)
+
+	tzk.zk = zk
+}
+
+func (tzk testZK) close() {
+	tzk.printLogs()
+	tzk.zk.Destroy()
 }
 
 func createTestZk(t *testing.T) testZK {
@@ -54,6 +70,8 @@ func createTestZk(t *testing.T) testZK {
 
 	return testZK{
 		T:    t,
+		port: port,
+		home: zkHome,
 		dir:  dir,
 		addr: fmt.Sprintf("127.0.0.1:%d", port),
 		zk:   zk,
@@ -61,16 +79,57 @@ func createTestZk(t *testing.T) testZK {
 }
 
 func connectZookeeperTest(t *testing.T) (*zkWatcher, testZK) {
-	zk := createTestZk(t)
-	defer zk.close()
+	tzk := createTestZk(t)
 
-	zkWatcher, err := connectZookeeper([]string{zk.addr}, "/test-sequins", 5*time.Second, 10*time.Second)
+	zkWatcher, err := connectZookeeper([]string{tzk.addr}, "/sequins-test", 5*time.Second, 10*time.Second)
 	require.NoError(t, err, "zkWatcher should connect")
 
-	return zkWatcher, zk
+	return zkWatcher, tzk
+}
+
+func expectWatchUpdate(t *testing.T, expected []string, updates chan []string, msg string) {
+	timer := time.NewTimer(10 * time.Second)
+	select {
+	case update := <-updates:
+		assert.Equal(t, expected, update, msg)
+	case <-timer.C:
+		require.FailNow(t, "timed out waiting for update")
+	}
 }
 
 func TestZKWatcher(t *testing.T) {
-	// TODO this test needs to be fleshed out
-	connectZookeeperTest(t)
+	w, tzk := connectZookeeperTest(t)
+	defer w.close()
+	defer tzk.close()
+
+	err := w.createPath("/foo")
+	require.NoError(t, err, "createPath should work")
+
+	updates, _ := w.watchChildren("/foo")
+	go func() {
+		w.createEphemeral("/foo/bar")
+		time.Sleep(100 * time.Millisecond)
+		w.removeEphemeral("/foo/bar")
+	}()
+
+	expectWatchUpdate(t, nil, updates, "the list of children should be updated to be empty first")
+	expectWatchUpdate(t, []string{"bar"}, updates, "the list of children should be updated with the new node")
+	expectWatchUpdate(t, nil, updates, "the list of children should be updated to be empty again")
+}
+
+func TestZKWatchesCanceled(t *testing.T) {
+	w, tzk := connectZookeeperTest(t)
+	defer w.close()
+	defer tzk.close()
+
+	err := w.createPath("/foo")
+	require.NoError(t, err, "createPath should work")
+
+	w.watchChildren("/foo")
+
+	for i := 0; i < 3; i++ {
+		tzk.restart()
+	}
+
+	assert.Equal(t, 1, zk.CountPendingWatches(), "there should only be a single watch open")
 }


### PR DESCRIPTION
The new tests caught two (minor) bugs in zkWatcher:

 - `break` inside a switch statement just breaks out of the switch,
   so we weren't properly closing watches on shutdown

 - There was a missing `return` inside `hookWatchChildren` which was
   causing the watch to 'leak'; to continue inside the loop even
   when the connection to zookeeper closed. In some very specific
   conditions, this could cause zkWatcher to infinitely reconnect.

 - We don't need to throw away the connection when we get `STATE_CONNECTING`

 - Access to `w.conn` wasn't synchronized, which lead to a possible (but extremely unlikely) data race