### PR TITLE
Add a response header 'X-Sequins-Proxied-To'

### DIFF
--- a/proxy_test.go
+++ b/proxy_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -30,6 +31,7 @@ func httptestHost(s *httptest.Server) string {
 }
 
 func TestProxySinglePeer(t *testing.T) {
+	w := httptest.NewRecorder()
 	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "all good")
 	}))
@@ -37,12 +39,16 @@ func TestProxySinglePeer(t *testing.T) {
 	peers := []string{httptestHost(peer)}
 
 	r, _ := http.NewRequest("GET", "http://localhost", nil)
-	res, err := proxyTestVersion.proxy(r, peers)
+	res, err := proxyTestVersion.proxy(w, r, peers)
+	// Port changes on every test run.
+	host, _, err := net.SplitHostPort(w.Header().Get("X-Sequins-Proxied-to"))
+	assert.Equal(t, host, "127.0.0.1")
 	assert.NoError(t, err, "simple proxying should work")
 	assert.NotNil(t, res, "simple proxying should work")
 }
 
 func TestProxySlowPeer(t *testing.T) {
+	w := httptest.NewRecorder()
 	slowPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(100 * time.Millisecond)
 		fmt.Fprintln(w, "sorry, did you need something?")
@@ -58,7 +64,7 @@ func TestProxySlowPeer(t *testing.T) {
 
 	peers := []string{httptestHost(slowPeer), httptestHost(goodPeer), httptestHost(notReachedPeer)}
 	r, _ := http.NewRequest("GET", "http://localhost", nil)
-	res, err := proxyTestVersion.proxy(r, peers)
+	res, err := proxyTestVersion.proxy(w, r, peers)
 	require.NoError(t, err, "proxying should work on the second peer")
 	require.NotNil(t, res, "proxying should work on the second peer")
 
@@ -66,6 +72,7 @@ func TestProxySlowPeer(t *testing.T) {
 }
 
 func TestProxyErrorPeer(t *testing.T) {
+	w := httptest.NewRecorder()
 	errorPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
 	}))
@@ -80,7 +87,7 @@ func TestProxyErrorPeer(t *testing.T) {
 
 	peers := []string{httptestHost(errorPeer), httptestHost(goodPeer), httptestHost(notReachedPeer)}
 	r, _ := http.NewRequest("GET", "http://localhost", nil)
-	res, err := proxyTestVersion.proxy(r, peers)
+	res, err := proxyTestVersion.proxy(w, r, peers)
 	require.NoError(t, err, "proxying should work on the second peer")
 	require.NotNil(t, res, "proxying should work on the second peer")
 
@@ -88,6 +95,7 @@ func TestProxyErrorPeer(t *testing.T) {
 }
 
 func TestProxySlowPeerErrorPeer(t *testing.T) {
+	w := httptest.NewRecorder()
 	slowPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(15 * time.Millisecond)
 		fmt.Fprintln(w, "all good, sorry to keep you waiting")
@@ -99,7 +107,7 @@ func TestProxySlowPeerErrorPeer(t *testing.T) {
 
 	peers := []string{httptestHost(slowPeer), httptestHost(errorPeer)}
 	r, _ := http.NewRequest("GET", "http://localhost", nil)
-	res, err := proxyTestVersion.proxy(r, peers)
+	res, err := proxyTestVersion.proxy(w, r, peers)
 	require.NoError(t, err, "proxying should work on the first peer")
 	require.NotNil(t, res, "proxying should work on the first peer")
 
@@ -107,6 +115,7 @@ func TestProxySlowPeerErrorPeer(t *testing.T) {
 }
 
 func TestProxyTimeout(t *testing.T) {
+	w := httptest.NewRecorder()
 	slowPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(100 * time.Millisecond)
 		fmt.Fprintln(w, "sorry, did you need something?")
@@ -124,12 +133,13 @@ func TestProxyTimeout(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest("GET", "http://localhost", nil)
-	res, err := proxyTestVersion.proxy(r, peers)
+	res, err := proxyTestVersion.proxy(w, r, peers)
 	assert.Equal(t, errProxyTimeout, err, "proxying should time out with all slow peers")
 	assert.Nil(t, res, "proxying should time out with all slow peers")
 }
 
 func TestProxyErrors(t *testing.T) {
+	w := httptest.NewRecorder()
 	errorPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
 	}))
@@ -141,7 +151,7 @@ func TestProxyErrors(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest("GET", "http://localhost", nil)
-	res, err := proxyTestVersion.proxy(r, peers)
+	res, err := proxyTestVersion.proxy(w, r, peers)
 	assert.Equal(t, errNoAvailablePeers, err, "proxying should return errNoAvailablePeers if all error")
 	assert.Nil(t, res, "proxying should return errNoAvailablePeers if all error")
 }

--- a/version.go
+++ b/version.go
@@ -102,7 +102,7 @@ func (vs *version) advertiseAndWait() bool {
 
 // serveKey is the entrypoint for incoming HTTP requests.
 func (vs *version) serveKey(w http.ResponseWriter, r *http.Request, key string) {
-	res, err := vs.get(r, key)
+	res, err := vs.get(w, r, key)
 
 	if err == errNoAvailablePeers {
 		// Either something is wrong with sharding, or all peers errored for some
@@ -133,7 +133,7 @@ func (vs *version) serveKey(w http.ResponseWriter, r *http.Request, key string) 
 
 // get looks up a value locally, or, failing that, asks a peer that has it.
 // If the request was proxied, it is not proxied further.
-func (vs *version) get(r *http.Request, key string) ([]byte, error) {
+func (vs *version) get(w http.ResponseWriter, r *http.Request, key string) ([]byte, error) {
 	if vs.numPartitions == 0 {
 		return nil, nil
 	}
@@ -141,12 +141,13 @@ func (vs *version) get(r *http.Request, key string) ([]byte, error) {
 	partition, alternatePartition := blocks.KeyPartition(key, vs.numPartitions)
 	bs := vs.getBlockStore()
 	if bs != nil && vs.hasPartition(partition) || vs.hasPartition(alternatePartition) {
-		return bs.Get(key)
+		res, err := bs.Get(key)
+		return res, err
 	} else if r.URL.Query().Get("proxy") == "" {
-		res, err := vs.getPeers(r, partition)
+		res, err := vs.getPeers(w, r, partition)
 		if res == nil && err == nil && alternatePartition != partition {
 			log.Println("Trying alternate partition for pathological key", key)
-			res, err = vs.getPeers(r, alternatePartition)
+			res, err = vs.getPeers(w, r, alternatePartition)
 		}
 
 		return res, err
@@ -156,7 +157,7 @@ func (vs *version) get(r *http.Request, key string) ([]byte, error) {
 
 }
 
-func (vs *version) getPeers(r *http.Request, partition int) ([]byte, error) {
+func (vs *version) getPeers(w http.ResponseWriter, r *http.Request, partition int) ([]byte, error) {
 	peers := vs.partitions.getPeers(partition)
 	if len(peers) == 0 {
 		return nil, errNoAvailablePeers
@@ -170,7 +171,7 @@ func (vs *version) getPeers(r *http.Request, partition int) ([]byte, error) {
 		shuffled[v] = peers[i]
 	}
 
-	return vs.proxy(r, peers)
+	return vs.proxy(w, r, peers)
 }
 
 // hasPartition returns true if we have the partition available locally.


### PR DESCRIPTION
# What does this PR do?
Exposes which server handled the request to the client, though a response header `X-Sequins-Proxied-To` 

# Why?
To increase visibility on how many requests are proxied though sequins.  With this data we can chart if requests become slow though proxying or not. 

r @colinmarc 