### PR TITLE
Fix a race condition when closing a watch

### DIFF
--- a/zk_watcher.go
+++ b/zk_watcher.go
@@ -287,7 +287,11 @@ func (w *zkWatcher) hookWatchChildren(node string, wn watchedNode) error {
 
 	go func() {
 		for {
-			wn.updates <- children
+			select {
+			case <-wn.cancel:
+				return
+			case wn.updates <- children:
+			}
 
 			select {
 			case <-wn.cancel:


### PR DESCRIPTION
If the watch was blocked on sending updates to the client process,
then it would panic trying to send on the closed `updates` chan. We can
make sure we catch `cancel`, too, with a `select`.

r? @scottjab 