### PR TITLE
Fix a race when removing watches (for real this time)

### DIFF
--- a/zk_watcher_test.go
+++ b/zk_watcher_test.go
@@ -155,3 +155,50 @@ func TestZKWatchesCanceled(t *testing.T) {
 
 	assert.Equal(t, 1, zk.CountPendingWatches(), "there should only be a single watch open")
 }
+
+func TestZKRemoveWatch(t *testing.T) {
+	w, tzk := connectZookeeperTest(t)
+	defer w.close()
+	defer tzk.close()
+
+	err := w.createPath("/foo")
+	require.NoError(t, err, "createPath should work")
+
+	updates, disconnected := w.watchChildren("/foo")
+
+	w.createEphemeral("/foo/bar")
+	expectWatchUpdate(t, nil, updates, "the list of children should be updated to be empty first")
+	expectWatchUpdate(t, []string{"bar"}, updates, "the list of children should be updated with the new node")
+
+	w.removeWatch("/foo")
+
+	// This is a sketchy way to make sure the updates channel gets closed.
+	closed := make(chan bool)
+	go func() {
+		for range updates {
+		}
+		closed <- true
+	}()
+
+	timer := time.NewTimer(100 * time.Millisecond)
+	select {
+	case <-closed:
+	case <-timer.C:
+		assert.Fail(t, "the updates channel should be closed")
+	}
+
+	// And again for disconnected. This can't be a method, since updates and
+	// disconnected don't have the same type.
+	go func() {
+		for range disconnected {
+		}
+		closed <- true
+	}()
+
+	timer.Reset(100 * time.Millisecond)
+	select {
+	case <-closed:
+	case <-timer.C:
+		assert.Fail(t, "the disconnected channel should be closed")
+	}
+}


### PR DESCRIPTION
example demonstrates: https://play.golang.org/p/doj48elk2B

This is a real fix, whereby we let the hookWatchChildren loop close
the client channels itself, but only if it's exiting for the last
time.

This time around, I added a test for the behavior.

r? @scottjab 