### PR TITLE
Close the block store if we fail to build it

### DIFF
--- a/blocks/block_store.go
+++ b/blocks/block_store.go
@@ -263,8 +263,15 @@ func (store *BlockStore) Count() int {
 
 // Close closes the BlockStore, and any files it has open.
 func (store *BlockStore) Close() {
+	store.blockMapLock.Lock()
+	defer store.blockMapLock.Unlock()
+
 	for _, block := range store.Blocks {
 		block.Close()
+	}
+
+	for _, newBlock := range store.newBlocks {
+		newBlock.close()
 	}
 }
 

--- a/blocks/block_writer.go
+++ b/blocks/block_writer.go
@@ -101,3 +101,7 @@ func (bw *blockWriter) save() (*Block, error) {
 
 	return b, nil
 }
+
+func (bw *blockWriter) close() {
+	bw.sparkeyWriter.Close()
+}

--- a/build.go
+++ b/build.go
@@ -117,6 +117,8 @@ func (vs *version) createStore(files []string, partitions map[int]bool) (*blocks
 	for _, file := range files {
 		err := vs.addFile(blockStore, file)
 		if err != nil {
+			blockStore.Close()
+			blockStore.Delete()
 			return nil, err
 		}
 	}


### PR DESCRIPTION
In the case that we hit an error while adding files, this could leak
file descriptors; We'd close any flushed blocks, but not the ones
open for writing.

r? @kitchen 