### PR TITLE
Support hadoop.io.Text and bare values in addition to hadoop.io.BytesWritable

### DIFF
--- a/build.go
+++ b/build.go
@@ -144,12 +144,6 @@ func (vs *version) addFile(bs *blocks.BlockStore, file string) error {
 		return fmt.Errorf("reading header from %s: %s", disp, err)
 	}
 
-	if sf.Header.KeyClassName != "org.apache.hadoop.io.BytesWritable" {
-		return fmt.Errorf("Unsupported sequencefile key serialization: %s", sf.Header.KeyClassName)
-	} else if sf.Header.ValueClassName != "org.apache.hadoop.io.BytesWritable" {
-		return fmt.Errorf("Unsupported sequencefile value serialization: %s", sf.Header.ValueClassName)
-	}
-
 	err = bs.AddFile(sf, vs.sequins.config.ThrottleLoads.Duration)
 	if err == blocks.ErrWrongPartition {
 		log.Println("Skipping", disp, "because it contains no relevant partitions")

--- a/vendor/github.com/colinmarc/sequencefile/writable.go
+++ b/vendor/github.com/colinmarc/sequencefile/writable.go
@@ -6,6 +6,13 @@ import (
 	"fmt"
 )
 
+const (
+	BytesWritableClassName = "org.apache.hadoop.io.BytesWritable"
+	TextClassName          = "org.apache.hadoop.io.Text"
+	IntWritableClassName   = "org.apache.hadoop.io.IntWritable"
+	LongWritableClassName  = "org.apache.hadoop.io.LongWritable"
+)
+
 // BytesWritable unwraps a hadoop BytesWritable and returns the actual bytes.
 func BytesWritable(b []byte) []byte {
 	return b[4:]

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -46,7 +46,8 @@
 		{
 			"importpath": "github.com/colinmarc/sequencefile",
 			"repository": "https://github.com/colinmarc/sequencefile",
-			"revision": "183d17e59ea5261aa7c54e46fcd3043cd3895354",
+			"vcs": "git",
+			"revision": "1b9a884c88da07bef4eb54a82a94ef2e196a2c89",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
Hadoop does this silly key/value serialization thing where it has a serialization class for the key and for the value. In practice, that means that each key and value serialized as [BytesWritable][0] has four bytes wasted at the front for the length of it (wasted because SequenceFile length-prefixes the values too).

I realized while writing the manual that BytesWritable as the only supported key/value serialization was both arbitrary and kinda wasteful. It's [not hard][1] to write "raw" bytes for keys and values, and [Text][2] is another fairly common ["Writable"][3] that uses a single byte to length-prefix (it's actually a weird varint-like thing they call a VInt, but usually it's just one byte).

I figured we may as well support all three. It's easier than being super strict in the docs.

[0]: https://hadoop.apache.org/docs/r2.6.1/api/org/apache/hadoop/io/BytesWritable.html
[1]: https://hadoop.apache.org/docs/current/api/org/apache/hadoop/mapred/SequenceFileAsBinaryOutputFormat.html
[2]: https://hadoop.apache.org/docs/r2.6.1/api/org/apache/hadoop/io/Text.html
[3]: https://hadoop.apache.org/docs/r2.6.1/api/org/apache/hadoop/io/Writable.html

r? @kitchen 