### PR TITLE
Rename 'root' to 'source', and add a bunch of path validation

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Backend interface {
-	// Lists all valid DBs (the first set of directories under the root).
+	// Lists all valid DBs (the first set of directories under the source root).
 	ListDBs() ([]string, error)
 
 	// ListVersions returns a sorted list of valid versions for the given db. If

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -37,7 +37,7 @@ const (
 type testCluster struct {
 	*testing.T
 	binary     string
-	root       string
+	source     string
 	sequinses  []*testSequins
 	zk         *testZK
 	testClient *http.Client
@@ -65,7 +65,7 @@ func newTestCluster(t *testing.T) *testCluster {
 		t.Skip("Skipping functional cluster tests because no binary is available. Please run the tests with 'make test'.")
 	}
 
-	root, err := ioutil.TempDir("", "sequins-cluster-")
+	source, err := ioutil.TempDir("", "sequins-cluster-")
 	require.NoError(t, err)
 
 	zk := createTestZk(t)
@@ -83,7 +83,7 @@ func newTestCluster(t *testing.T) *testCluster {
 	return &testCluster{
 		T:          t,
 		binary:     binary,
-		root:       root,
+		source:     source,
 		sequinses:  make([]*testSequins, 0),
 		zk:         zk,
 		testClient: testClient,
@@ -92,7 +92,7 @@ func newTestCluster(t *testing.T) *testCluster {
 
 func (tc *testCluster) addSequins() *testSequins {
 	port := randomPort()
-	path := filepath.Join(tc.root, fmt.Sprintf("node-%d", port))
+	path := filepath.Join(tc.source, fmt.Sprintf("node-%d", port))
 
 	storePath := filepath.Join(path, "store")
 	err := os.MkdirAll(storePath, 0755|os.ModeDir)
@@ -107,7 +107,7 @@ func (tc *testCluster) addSequins() *testSequins {
 	config := defaultConfig()
 	name := fmt.Sprintf("localhost:%d", port)
 	config.Bind = name
-	config.Root = backendPath
+	config.Source = backendPath
 	config.LocalStore = path
 	config.RequireSuccessFile = true
 	config.Sharding.Enabled = true
@@ -192,7 +192,7 @@ func (tc *testCluster) tearDown() {
 	}
 
 	tc.zk.close()
-	os.RemoveAll(tc.root)
+	os.RemoveAll(tc.source)
 }
 
 func (ts *testSequins) expectProgression(versions ...testVersion) {

--- a/config.go
+++ b/config.go
@@ -17,7 +17,7 @@ const defaultSearchPath = "sequins.conf:/etc/sequins.conf"
 var errNoConfig = errors.New("no config file found")
 
 type sequinsConfig struct {
-	Root               string   `toml:"root"`
+	Source             string   `toml:"source"`
 	Bind               string   `toml:"bind"`
 	MaxParallelLoads   int      `toml:"max_parallel_loads"`
 	ThrottleLoads      duration `toml:"throttle_loads"`
@@ -79,7 +79,7 @@ type testConfig struct {
 
 func defaultConfig() sequinsConfig {
 	return sequinsConfig{
-		Root:               "",
+		Source:             "",
 		Bind:               "0.0.0.0:9599",
 		LocalStore:         "/var/sequins/",
 		MaxParallelLoads:   0,

--- a/config_test.go
+++ b/config_test.go
@@ -15,6 +15,15 @@ import (
 
 var commentedDefaultRegex = regexp.MustCompile(`# (\w+ = .+)\n(?:#.*\n)*\n*`)
 
+func loadAndValidateConfig(path string) (sequinsConfig, error) {
+	config, err := loadConfig(path)
+	if err != nil {
+		return config, err
+	}
+
+	return validateConfig(config)
+}
+
 func createTestConfig(t *testing.T, conf string) string {
 	tmpfile, err := ioutil.TempFile("", "sequins-conf-test")
 	if err != nil {
@@ -35,7 +44,7 @@ func createTestConfig(t *testing.T, conf string) string {
 }
 
 func TestExampleConfig(t *testing.T) {
-	config, err := loadConfig("sequins.conf.example")
+	config, err := loadAndValidateConfig("sequins.conf.example")
 	require.NoError(t, err, "sequins.conf.example should exist and be valid")
 
 	defaults := defaultConfig()
@@ -62,7 +71,7 @@ func TestExampleConfigDefaults(t *testing.T) {
 
 	t.Logf("---replaced config---\n%s\n---replaced config---", string(replaced))
 	path := createTestConfig(t, string(replaced))
-	config, err := loadConfig(path)
+	config, err := loadAndValidateConfig(path)
 	require.NoError(t, err, "the uncommented sequins.conf.example should exist and be valid")
 
 	defaults := defaultConfig()
@@ -82,7 +91,7 @@ func TestSimpleConfig(t *testing.T) {
 		servers = ["zk:2181"]
 	`)
 
-	config, err := loadConfig(path)
+	config, err := loadAndValidateConfig(path)
 	require.NoError(t, err, "loading a basic config should work")
 
 	assert.Equal(t, "s3://foo/bar", config.Source, "Source should be set")
@@ -101,20 +110,24 @@ func TestSimpleConfig(t *testing.T) {
 }
 
 func TestEmptyConfig(t *testing.T) {
-	path := createTestConfig(t, "")
+	path := createTestConfig(t, "source = \"/foo\"")
 
-	config, err := loadConfig(path)
+	config, err := loadAndValidateConfig(path)
 	require.NoError(t, err, "loading an empty config should work")
+
+	assert.Equal(t, "/foo", config.Source, "the root should be set")
+
+	config.Source = ""
 	assert.Equal(t, defaultConfig(), config, "an empty config should eval to the default config")
 }
 
 func TestConfigSearchPath(t *testing.T) {
-	path := createTestConfig(t, "")
+	path := createTestConfig(t, "source = \"/foo\"")
 
-	_, err := loadConfig(fmt.Sprintf("%s:/this/doesnt/exist.conf", path))
+	_, err := loadAndValidateConfig(fmt.Sprintf("%s:/this/doesnt/exist.conf", path))
 	assert.NoError(t, err, "it should find the config file on the search path")
 
-	_, err = loadConfig(fmt.Sprintf("/this/doesnt/exist.conf:%s", path))
+	_, err = loadAndValidateConfig(fmt.Sprintf("/this/doesnt/exist.conf:%s", path))
 	assert.NoError(t, err, "it should find the config file on the search path")
 
 	os.Remove(path)
@@ -132,7 +145,7 @@ func TestConfigExtraKeys(t *testing.T) {
 		foo = "bar" # not a real config property!
 	`)
 
-	_, err := loadConfig(path)
+	_, err := loadAndValidateConfig(path)
 	assert.Error(t, err, "it should throw an error if there are extra config properties")
 
 	os.Remove(path)
@@ -148,8 +161,48 @@ func TestConfigInvalidCompression(t *testing.T) {
     compression = "notacompression"
   `)
 
-	_, err := loadConfig(path)
+	_, err := loadAndValidateConfig(path)
 	assert.Error(t, err, "it should throw an error if an invalid compression is specified")
 
 	os.Remove(path)
+}
+
+func TestConfigRelativeSource(t *testing.T) {
+	path := createTestConfig(t, `
+    source = "foo/bar"
+    local_store = "/foo/bar/baz"
+  `)
+
+	_, err := loadAndValidateConfig(path)
+	assert.Error(t, err, "it should throw an error if the source root is a relative path")
+}
+
+func TestConfigRelativeSourceURL(t *testing.T) {
+	path := createTestConfig(t, `
+    source = "file://foo/bar"
+    local_store = "/foo/bar/baz"
+  `)
+
+	_, err := loadAndValidateConfig(path)
+	assert.Error(t, err, "it should throw an error if the source root is a relative path")
+}
+
+func TestConfigRelativeLocalStore(t *testing.T) {
+	path := createTestConfig(t, `
+    source = "/foo/bar"
+    local_store = "bar/baz"
+  `)
+
+	_, err := loadAndValidateConfig(path)
+	assert.Error(t, err, "it should throw an error if the local store is a relative path")
+}
+
+func TestConfigLocalStoreWithinRoot(t *testing.T) {
+	path := createTestConfig(t, `
+    source = "/foo/bar"
+    local_store = "/foo/bar/baz"
+  `)
+
+	_, err := loadAndValidateConfig(path)
+	assert.Error(t, err, "it should throw an error if the local store is within the source root")
 }

--- a/config_test.go
+++ b/config_test.go
@@ -39,7 +39,7 @@ func TestExampleConfig(t *testing.T) {
 	require.NoError(t, err, "sequins.conf.example should exist and be valid")
 
 	defaults := defaultConfig()
-	defaults.Root = config.Root
+	defaults.Source = config.Source
 	assert.Equal(t, defaults, config, "sequins.conf.example should eval to the default config")
 }
 
@@ -66,7 +66,7 @@ func TestExampleConfigDefaults(t *testing.T) {
 	require.NoError(t, err, "the uncommented sequins.conf.example should exist and be valid")
 
 	defaults := defaultConfig()
-	defaults.Root = config.Root
+	defaults.Source = config.Source
 	assert.Equal(t, defaults, config, "the uncommented sequins.conf.example should eval to the default config")
 
 	os.Remove(path)
@@ -74,7 +74,7 @@ func TestExampleConfigDefaults(t *testing.T) {
 
 func TestSimpleConfig(t *testing.T) {
 	path := createTestConfig(t, `
-		root = "s3://foo/bar"
+		source = "s3://foo/bar"
 		require_success_file = true
 		refresh_period = "1h"
 
@@ -85,13 +85,13 @@ func TestSimpleConfig(t *testing.T) {
 	config, err := loadConfig(path)
 	require.NoError(t, err, "loading a basic config should work")
 
-	assert.Equal(t, "s3://foo/bar", config.Root, "Root should be set")
+	assert.Equal(t, "s3://foo/bar", config.Source, "Source should be set")
 	assert.Equal(t, true, config.RequireSuccessFile, "RequireSuccessFile should be set")
 	assert.Equal(t, time.Hour, config.RefreshPeriod.Duration, "RefreshPeriod (a duration) should be set")
 	assert.Equal(t, []string{"zk:2181"}, config.ZK.Servers, "ZK.Servers should be set")
 
 	defaults := defaultConfig()
-	defaults.Root = config.Root
+	defaults.Source = config.Source
 	defaults.RequireSuccessFile = config.RequireSuccessFile
 	defaults.RefreshPeriod = config.RefreshPeriod
 	defaults.ZK.Servers = config.ZK.Servers
@@ -122,7 +122,7 @@ func TestConfigSearchPath(t *testing.T) {
 
 func TestConfigExtraKeys(t *testing.T) {
 	path := createTestConfig(t, `
-		root = "s3://foo/bar"
+		source = "s3://foo/bar"
 		require_success_file = true
 		refresh_period = "1h"
 
@@ -140,7 +140,7 @@ func TestConfigExtraKeys(t *testing.T) {
 
 func TestConfigInvalidCompression(t *testing.T) {
 	path := createTestConfig(t, `
-    root = "s3://foo/bar"
+    source = "s3://foo/bar"
     require_success_file = true
     refresh_period = "1h"
 

--- a/hdfs_sequins_test.go
+++ b/hdfs_sequins_test.go
@@ -26,13 +26,13 @@ func setupHdfs(t *testing.T) *backend.HdfsBackend {
 	}
 
 	infos, _ := ioutil.ReadDir("test/baby-names/1")
-	rootDest := path.Join("/", "_test_sequins", "baby-names")
+	sourceDest := path.Join("/", "_test_sequins", "baby-names")
 	for _, info := range infos {
-		putHDFS(client, path.Join(rootDest, "0", info.Name()), filepath.Join("test/baby-names/1", info.Name()))
-		putHDFS(client, path.Join(rootDest, "1", info.Name()), filepath.Join("test/baby-names/1", info.Name()))
+		putHDFS(client, path.Join(sourceDest, "0", info.Name()), filepath.Join("test/baby-names/1", info.Name()))
+		putHDFS(client, path.Join(sourceDest, "1", info.Name()), filepath.Join("test/baby-names/1", info.Name()))
 	}
 
-	client.CreateEmptyFile(path.Join(rootDest, "0", "_SUCCESS"))
+	client.CreateEmptyFile(path.Join(sourceDest, "0", "_SUCCESS"))
 	return backend.NewHdfsBackend(client, nn, "/_test_sequins")
 }
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"path/filepath"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -43,7 +44,22 @@ func main() {
 	}
 
 	if *source != "" {
-		config.Source = *source
+		parsed, err := url.Parse(*source)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		switch parsed.Scheme {
+		case "":
+			absPath, err := filepath.Abs(parsed.Path)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			config.Source = absPath
+		default:
+			config.Source = *source
+		}
 	}
 
 	if config.Source == "" {
@@ -55,7 +71,12 @@ func main() {
 	}
 
 	if *localStore != "" {
-		config.LocalStore = *localStore
+		absPath, err := filepath.Abs(*localStore)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		config.LocalStore = absPath
 	}
 
 	if *debugBind != "" {

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ var (
 	sequinsVersion string
 
 	bind       = kingpin.Flag("bind", "Address to bind to. Overrides the config option of the same name.").Short('b').PlaceHolder("ADDRESS").String()
-	root       = kingpin.Flag("root", "Where the sequencefiles are. Overrides the config option of the same name.").Short('r').PlaceHolder("URI").String()
+	source     = kingpin.Flag("source", "Where the sequencefiles are. Overrides the config option of the same name.").Short('r').PlaceHolder("URI").String()
 	localStore = kingpin.Flag("local-store", "Where to store local data. Overrides the config option of the same name.").Short('l').PlaceHolder("PATH").String()
 	configPath = kingpin.Flag("config", "The config file to use. By default, either sequins.conf in the local directory or /etc/sequins.conf will be used.").PlaceHolder("PATH").String()
 	debugBind  = kingpin.Flag("debug-bind", "Address to bind to for pprof and expvars. Overrides the config option of the same name.").PlaceHolder("ADDRESS").String()
@@ -33,8 +33,8 @@ func main() {
 
 	config, err := loadConfig(*configPath)
 	if err == errNoConfig {
-		// If --root was specified, we can just use that and the default config.
-		if *root != "" {
+		// If --source was specified, we can just use that and the default config.
+		if *source != "" {
 			config = defaultConfig()
 		} else {
 			log.Fatal("No config file found! Please see the README for instructions.")
@@ -43,12 +43,12 @@ func main() {
 		log.Fatal("Error loading config: ", err)
 	}
 
-	if *root != "" {
-		config.Root = *root
+	if *source != "" {
+		config.Source = *source
 	}
 
-	if config.Root == "" {
-		log.Fatal("Root must be defined, either in the config file or with --root. Please see the README for instructions.")
+	if config.Source == "" {
+		log.Fatal("The source root must be defined, either in the config file or with --source. Please see the README for instructions.")
 	}
 
 	if *bind != "" {
@@ -63,7 +63,7 @@ func main() {
 		config.Debug.Bind = *debugBind
 	}
 
-	parsed, err := url.Parse(config.Root)
+	parsed, err := url.Parse(config.Source)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func main() {
 		if config.Sharding.Enabled && !config.Test.AllowLocalCluster {
 			log.Fatal("You can't run sequins with sharding enabled on local paths.")
 		}
-		s = localSetup(config.Root, config)
+		s = localSetup(config.Source, config)
 	case "s3":
 		s = s3Setup(parsed.Host, parsed.Path, config)
 	case "hdfs":

--- a/s3_sequins_test.go
+++ b/s3_sequins_test.go
@@ -30,12 +30,12 @@ func setupS3(t *testing.T) *backend.S3Backend {
 	testBackend := backend.NewS3Backend(bucket, "test", svc)
 
 	infos, _ := ioutil.ReadDir("test/baby-names/1")
-	rootDest := path.Join("test", "baby-names")
+	sourceDest := path.Join("test", "baby-names")
 	for _, info := range infos {
-		err := putS3(svc, bucket, path.Join(rootDest, "0", info.Name()), filepath.Join("test/baby-names/1", info.Name()))
-		require.NoError(t, err, "setup: putting %s", path.Join(rootDest, "0", info.Name()))
-		err = putS3(svc, bucket, path.Join(rootDest, "1", info.Name()), filepath.Join("test/baby-names/1", info.Name()))
-		require.NoError(t, err, "setup: putting %s", path.Join(rootDest, "1", info.Name()))
+		err := putS3(svc, bucket, path.Join(sourceDest, "0", info.Name()), filepath.Join("test/baby-names/1", info.Name()))
+		require.NoError(t, err, "setup: putting %s", path.Join(sourceDest, "0", info.Name()))
+		err = putS3(svc, bucket, path.Join(sourceDest, "1", info.Name()), filepath.Join("test/baby-names/1", info.Name()))
+		require.NoError(t, err, "setup: putting %s", path.Join(sourceDest, "1", info.Name()))
 	}
 
 	putS3Blob(svc, bucket, "test/baby-names/0/_SUCCESS", nil)

--- a/sequins.conf.example
+++ b/sequins.conf.example
@@ -3,14 +3,14 @@
 
 # Unless specified otherwise, the below values are the defaults.
 
-root = "hdfs://namenode:8020/path/to/sequins"
+source = "hdfs://namenode:8020/path/to/sequins"
 # The url or directory where the sequencefiles are. This can be a local
 # directory, an HDFS url of the form hdfs://<namenode>:<port>/path/to/stuff,
 # or an S3 url of the form s3://<bucket>/path/to/stuff. This should be a
 # a directory of directories of directories; each first level represents a 'db',
 # and each subdirectory therein represents a 'version' of that db. See the
 # README for more information. This must be set, but can be overriden from the
-# command line with --root.
+# command line with --source.
 
 # bind = "0.0.0.0:9599"
 # The address to bind on. This can be overridden from the command line with

--- a/sequins_test.go
+++ b/sequins_test.go
@@ -170,7 +170,7 @@ func TestSequinsThreadsafe(t *testing.T) {
 	createTestIndex(t, scratch, 0)
 
 	config := defaultConfig()
-	config.Root = scratch
+	config.Source = scratch
 	config.LocalStore = filepath.Join(scratch, "blocks")
 	config.RequireSuccessFile = true
 	ts := newSequins(backend.NewLocalBackend(filepath.Join(scratch, "data")), config)


### PR DESCRIPTION
This renames the `root` configuration option to `source`, as we discussed. It also adds a bunch of validation (and tests for the validation):

  - Check that the source root and local store are absolute paths
  - Check that the former doesn't contain the latter
  - Make sure `file://` urls don't have a "host"
  - Error on schemes other than `file://`, `hdfs://`, or `s3://`

Finally, it adds a bit of code such that relative paths work, but only from the command line.

This is best reviewed commit by commit (since the first one is just s/root/source and is pretty chunderous). r? @kitchen 