### PR TITLE
Add support for streaming values to clients

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.6
+go: 1.7
 sudo: false
 before_install:
 - export ZOOKEEPER_HOME="$HOME/zookeeper-3.4.8"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.6
+FROM golang:1.7
 
 RUN apt-get update
 RUN apt-get install -y build-essential autoconf libtool pkg-config

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,10 @@ release: sequins
 	tar -cvzf $(RELEASE_NAME).tar.gz $(RELEASE_NAME)
 
 test: $(TEST_SOURCES)
-	$(CGO_PREAMBLE) go test -short -race -timeout 1m $(shell go list ./... | grep -v vendor)
+	$(CGO_PREAMBLE) go test -short -race -timeout 2m $(shell go list ./... | grep -v vendor)
+	# This test exercises some sync.Pool code, so it should be run without -race
+	# as well (sync.Pool doesn't ever share objects under -race).
+	$(CGO_PREAMBLE) go test -timeout 30s ./blocks -run TestBlockParallelReads
 
 test_functional: sequins $(TEST_SOURCES) test
 	$(CGO_PREAMBLE) go test -timeout 10m -run "^TestCluster"

--- a/blocks/block_store.go
+++ b/blocks/block_store.go
@@ -251,7 +251,7 @@ func (store *BlockStore) Save() error {
 
 // Get returns the value for a given key. It returns ErrPartitionNotFound if
 // the partition requested is not available locally.
-func (store *BlockStore) Get(key string) ([]byte, error) {
+func (store *BlockStore) Get(key string) (*Record, error) {
 	store.blockMapLock.RLock()
 	defer store.blockMapLock.RUnlock()
 

--- a/blocks/block_store_test.go
+++ b/blocks/block_store_test.go
@@ -27,11 +27,11 @@ func testBlockStoreCompression(t *testing.T, compression Compression) {
 
 	res, err := bs.Get("Alice")
 	require.NoError(t, err, "fetching value for 'Alice'")
-	assert.Equal(t, "Practice", string(res), "fetching value for 'Alice'")
+	assert.Equal(t, "Practice", readAll(t, res), "fetching value for 'Alice'")
 
 	res, err = bs.Get("Bob")
 	require.NoError(t, err, "fetching value for 'Bob'")
-	assert.Equal(t, "Hope", string(res), "fetching value for 'Bob'")
+	assert.Equal(t, "Hope", readAll(t, res), "fetching value for 'Bob'")
 
 	// Close the index, then load it from the manifest.
 	bs.Close()
@@ -43,11 +43,11 @@ func testBlockStoreCompression(t *testing.T, compression Compression) {
 
 	res, err = bs.Get("Alice")
 	require.NoError(t, err, "fetching value for 'Alice'")
-	assert.Equal(t, "Practice", string(res), "fetching value for 'Alice'")
+	assert.Equal(t, "Practice", readAll(t, res), "fetching value for 'Alice'")
 
 	res, err = bs.Get("Bob")
 	require.NoError(t, err, "fetching value for 'Bob'")
-	assert.Equal(t, "Hope", string(res), "fetching value for 'Bob'")
+	assert.Equal(t, "Hope", readAll(t, res), "fetching value for 'Bob'")
 }
 
 func TestBlockStoreSnappy(t *testing.T) {

--- a/blocks/block_test.go
+++ b/blocks/block_test.go
@@ -1,12 +1,35 @@
 package blocks
 
 import (
+	"bytes"
+	"io"
 	"io/ioutil"
+	"math/rand"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var letters = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func randBytes() []byte {
+	n := rand.Intn(32) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+
+	return b
+}
+
+func readAll(t *testing.T, r io.Reader) string {
+	b, err := ioutil.ReadAll(r)
+	require.NoError(t, err)
+	return string(b)
+}
 
 func TestBlock(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "sequins-test-")
@@ -28,13 +51,26 @@ func TestBlock(t *testing.T) {
 	assert.Equal(t, "foo", string(block.maxKey), "the maxKey should be correct")
 	assert.Equal(t, "baz", string(block.minKey), "the minKey should be correct")
 
+	record, err := block.get([]byte("foo"))
+	require.NoError(t, err, "fetching reader for 'foo'")
+	assert.NotNil(t, record, "the record should exist")
+
+	buf := new(bytes.Buffer)
+	_, err = record.WriteTo(buf)
+	assert.NoError(t, err, "WriteTo should work, too")
+	assert.Equal(t, "bar", readAll(t, buf), "fetching value for 'foo'")
+
+	record, err = block.get([]byte("nonexistent"))
+	require.NoError(t, err, "fetching reader for 'nonexistent'")
+	assert.Nil(t, record, "the record should not exist")
+
 	res, err := block.Get([]byte("foo"))
 	require.NoError(t, err, "fetching value for 'foo'")
-	assert.Equal(t, "bar", string(res), "fetching value for 'foo'")
+	assert.Equal(t, "bar", readAll(t, res), "fetching value for 'foo'")
 
 	res, err = block.Get([]byte("baz"))
 	require.NoError(t, err, "fetching value for 'baz'")
-	assert.Equal(t, "qux", string(res), "fetching value for 'baz'")
+	assert.Equal(t, "qux", readAll(t, res), "fetching value for 'baz'")
 
 	// Close the block and load it from the manifest.
 	manifest := block.manifest()
@@ -51,9 +87,53 @@ func TestBlock(t *testing.T) {
 
 	res, err = block.Get([]byte("foo"))
 	require.NoError(t, err, "fetching value for 'foo'")
-	assert.Equal(t, "bar", string(res), "fetching value for 'foo'")
+	assert.Equal(t, "bar", readAll(t, res), "fetching value for 'foo'")
 
 	res, err = block.Get([]byte("baz"))
 	require.NoError(t, err, "fetching value for 'baz'")
-	assert.Equal(t, "qux", string(res), "fetching value for 'baz'")
+	assert.Equal(t, "qux", readAll(t, res), "fetching value for 'baz'")
+}
+
+func TestBlockParallelReads(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "sequins-test-")
+	require.NoError(t, err, "creating a test tmpdir")
+
+	bw, err := newBlock(tmpDir, 1, "snappy", 8192)
+	require.NoError(t, err, "initializing a block")
+
+	expected := make([][][]byte, 0, 100)
+	for i := 0; i < cap(expected); i++ {
+		key := randBytes()
+		value := randBytes()
+		err := bw.add(key, value)
+		require.NoError(t, err)
+
+		expected = append(expected, [][]byte{key, value})
+	}
+
+	block, err := bw.save()
+	require.NoError(t, err, "saving the block")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go func() {
+			shuffled := make([][][]byte, len(expected))
+			for i, v := range rand.Perm(len(expected)) {
+				shuffled[v] = expected[i]
+			}
+
+			for _, record := range shuffled {
+				val, err := block.Get(record[0])
+				require.NoError(t, err)
+				assert.Equal(t, string(record[1]), readAll(t, val))
+
+				time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
+			}
+
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
 }

--- a/blocks/block_writer.go
+++ b/blocks/block_writer.go
@@ -79,12 +79,7 @@ func (bw *blockWriter) save() (*Block, error) {
 
 	reader, err := sparkey.Open(bw.path)
 	if err != nil {
-		return nil, fmt.Errorf("opening block for reads: err")
-	}
-
-	iter, err := reader.Iterator()
-	if err != nil {
-		return nil, fmt.Errorf("opening block for reads: err")
+		return nil, fmt.Errorf("opening block: %s", err)
 	}
 
 	b := &Block{
@@ -93,10 +88,10 @@ func (bw *blockWriter) save() (*Block, error) {
 		Partition: bw.partition,
 		Count:     bw.count,
 
-		sparkeyReader: reader,
-		sparkeyIter:   iter,
 		minKey:        bw.minKey,
 		maxKey:        bw.maxKey,
+		sparkeyReader: reader,
+		iterPool:      newIterPool(reader),
 	}
 
 	return b, nil

--- a/blocks/hashcode.go
+++ b/blocks/hashcode.go
@@ -61,14 +61,13 @@ func KeyPartition(key string, totalPartitions int) (int, int) {
 // the first part, right? Wrong. It's almost identical. It's exactly 31
 // higher, because h starts at 1 instead of 0.
 //
-// For the vast majority of values, using the string hashCode intsead of the
+// For the vast majority of values, using the string hashCode instead of the
 // Tuple hashCode works fine; the partition numbers are different, but
 // consistently so. But this breaks down when the hashCode of the string is
 // within 31 of the max int32 value, or within 31 of 0, because we wrap before
 // doing the mod. One inconsistent partition number could cause us to assume a
 // whole file isn't actually partitioned, or, worse, ignore a key that's
-// actually in the dataset but that we skipped over while building a sparse
-// index.
+// actually in the dataset but that we skipped over heuristically.
 //
 // Fortunately, we can handle this case correctly. If the hashcode looks like
 // it would be pathological, then we can figure out what the cascading hashcode

--- a/blocks/iterpool.go
+++ b/blocks/iterpool.go
@@ -1,0 +1,46 @@
+package blocks
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"sync"
+
+	"github.com/bsm/go-sparkey"
+)
+
+var errOpenFailed = errors.New("failed to open block iter")
+
+// iterPool is a sync.Pool for *sparkey.HashIter objects. Since each one
+// represents a sparkey buffer in cgo, it's important to reuse them where
+// possible. Since cgo file descriptors don't get closed on GC, we use a
+// finalizer to do that.
+type iterPool struct {
+	sparkeyReader *sparkey.HashReader
+	*sync.Pool
+}
+
+// newIterPool creates a sync.Pool for *sparkey.HashIter objects.
+//
+// The new func returns nil if the sparkey.HashIter couldn't be created.
+func newIterPool(sparkeyReader *sparkey.HashReader) iterPool {
+	return iterPool{
+		sparkeyReader: sparkeyReader,
+		Pool:          new(sync.Pool),
+	}
+}
+
+func (ip iterPool) getIter() (*sparkey.HashIter, error) {
+	iter := ip.Get()
+	if iter == nil {
+		iter, err := ip.sparkeyReader.Iterator()
+		if err != nil {
+			return nil, fmt.Errorf("opening block iter: %s", err)
+		}
+
+		runtime.SetFinalizer(iter, (*sparkey.HashIter).Close)
+		return iter, nil
+	}
+
+	return iter.(*sparkey.HashIter), nil
+}

--- a/blocks/record.go
+++ b/blocks/record.go
@@ -1,0 +1,58 @@
+package blocks
+
+import (
+	"io"
+
+	"github.com/bsm/go-sparkey"
+)
+
+// A Record is one key/value pair loaded from a block.
+type Record struct {
+	ValueLen uint64
+
+	iterPool iterPool
+	iter     *sparkey.HashIter
+	reader   io.Reader
+	closed   bool
+}
+
+func (b *Block) get(key []byte) (*Record, error) {
+	iter, err := b.iterPool.getIter()
+	if err != nil {
+		// In the case of an error, the iter is no longer considered valid.
+		return nil, err
+	}
+
+	if err := iter.Seek(key); err != nil {
+		return nil, err
+	}
+
+	if iter.State() != sparkey.ITERATOR_ACTIVE {
+		// The key doesn't exist, so put the iterator back in the pool.
+		b.iterPool.Put(iter)
+		return nil, nil
+	}
+
+	return &Record{
+		ValueLen: iter.ValueLen(),
+		iterPool: b.iterPool,
+		iter:     iter,
+		reader:   iter.ValueReader(),
+	}, nil
+}
+
+func (r *Record) Read(b []byte) (int, error) {
+	return r.reader.Read(b)
+}
+
+func (r *Record) WriteTo(w io.Writer) (n int64, err error) {
+	return r.reader.(io.WriterTo).WriteTo(w)
+}
+
+func (r *Record) Close() error {
+	if r.iter != nil {
+		r.iterPool.Put(r.iter)
+	}
+
+	return nil
+}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -562,7 +562,9 @@ func TestClusterNodeWithoutData(t *testing.T) {
 	tc.sequinses[1].config.Test.VersionRemoveTimeout = duration{5 * time.Second}
 	tc.sequinses[2].config.Test.VersionRemoveTimeout = duration{5 * time.Second}
 
-	tc.sequinses[0].expectProgression(down, noVersion, v1, v3)
+	// Because it's behind, it's expected that the first node will flap when it
+	// proxies requests and gets v2 from peers.
+	// tc.sequinses[0].expectProgression(down, noVersion, v1, v3)
 	tc.sequinses[1].expectProgression(down, noVersion, v1, v2, v3)
 	tc.sequinses[2].expectProgression(down, noVersion, v1, v2, v3)
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"fmt"
-	"net"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -25,30 +26,34 @@ var proxyTestVersion = &version{
 	},
 }
 
+func readAll(t *testing.T, r io.Reader) string {
+	b, err := ioutil.ReadAll(r)
+	require.NoError(t, err)
+	return string(b)
+}
+
 func httptestHost(s *httptest.Server) string {
 	parsed, _ := url.Parse(s.URL)
 	return parsed.Host
 }
 
 func TestProxySinglePeer(t *testing.T) {
-	w := httptest.NewRecorder()
-	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	goodPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "all good")
 	}))
 
-	peers := []string{httptestHost(peer)}
-
+	peers := []string{httptestHost(goodPeer)}
 	r, _ := http.NewRequest("GET", "http://localhost", nil)
-	res, err := proxyTestVersion.proxy(w, r, peers)
-	// Port changes on every test run.
-	host, _, err := net.SplitHostPort(w.Header().Get("X-Sequins-Proxied-to"))
-	assert.Equal(t, host, "127.0.0.1")
-	assert.NoError(t, err, "simple proxying should work")
+	res, peer, err := proxyTestVersion.proxy(r, peers)
+
+	require.NoError(t, err, "simple proxying should work")
 	assert.NotNil(t, res, "simple proxying should work")
+
+	assert.Equal(t, httptestHost(goodPeer), peer, "the returned peer should be correct")
+	assert.Equal(t, "all good\n", readAll(t, res.Body))
 }
 
 func TestProxySlowPeer(t *testing.T) {
-	w := httptest.NewRecorder()
 	slowPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(100 * time.Millisecond)
 		fmt.Fprintln(w, "sorry, did you need something?")
@@ -64,15 +69,15 @@ func TestProxySlowPeer(t *testing.T) {
 
 	peers := []string{httptestHost(slowPeer), httptestHost(goodPeer), httptestHost(notReachedPeer)}
 	r, _ := http.NewRequest("GET", "http://localhost", nil)
-	res, err := proxyTestVersion.proxy(w, r, peers)
+	res, peer, err := proxyTestVersion.proxy(r, peers)
 	require.NoError(t, err, "proxying should work on the second peer")
 	require.NotNil(t, res, "proxying should work on the second peer")
 
-	assert.Equal(t, "all good\n", string(res))
+	assert.Equal(t, httptestHost(goodPeer), peer, "the returned peer should be correct")
+	assert.Equal(t, "all good\n", readAll(t, res.Body))
 }
 
 func TestProxyErrorPeer(t *testing.T) {
-	w := httptest.NewRecorder()
 	errorPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
 	}))
@@ -87,15 +92,16 @@ func TestProxyErrorPeer(t *testing.T) {
 
 	peers := []string{httptestHost(errorPeer), httptestHost(goodPeer), httptestHost(notReachedPeer)}
 	r, _ := http.NewRequest("GET", "http://localhost", nil)
-	res, err := proxyTestVersion.proxy(w, r, peers)
+	res, peer, err := proxyTestVersion.proxy(r, peers)
+
 	require.NoError(t, err, "proxying should work on the second peer")
 	require.NotNil(t, res, "proxying should work on the second peer")
 
-	assert.Equal(t, "all good\n", string(res))
+	assert.Equal(t, httptestHost(goodPeer), peer, "the returned peer should be correct")
+	assert.Equal(t, "all good\n", readAll(t, res.Body))
 }
 
 func TestProxySlowPeerErrorPeer(t *testing.T) {
-	w := httptest.NewRecorder()
 	slowPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(15 * time.Millisecond)
 		fmt.Fprintln(w, "all good, sorry to keep you waiting")
@@ -107,15 +113,16 @@ func TestProxySlowPeerErrorPeer(t *testing.T) {
 
 	peers := []string{httptestHost(slowPeer), httptestHost(errorPeer)}
 	r, _ := http.NewRequest("GET", "http://localhost", nil)
-	res, err := proxyTestVersion.proxy(w, r, peers)
+	res, peer, err := proxyTestVersion.proxy(r, peers)
+
 	require.NoError(t, err, "proxying should work on the first peer")
 	require.NotNil(t, res, "proxying should work on the first peer")
 
-	assert.Equal(t, "all good, sorry to keep you waiting\n", string(res))
+	assert.Equal(t, httptestHost(slowPeer), peer, "the returned peer should be correct")
+	assert.Equal(t, "all good, sorry to keep you waiting\n", readAll(t, res.Body))
 }
 
 func TestProxyTimeout(t *testing.T) {
-	w := httptest.NewRecorder()
 	slowPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(100 * time.Millisecond)
 		fmt.Fprintln(w, "sorry, did you need something?")
@@ -133,13 +140,14 @@ func TestProxyTimeout(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest("GET", "http://localhost", nil)
-	res, err := proxyTestVersion.proxy(w, r, peers)
+	res, peer, err := proxyTestVersion.proxy(r, peers)
+
 	assert.Equal(t, errProxyTimeout, err, "proxying should time out with all slow peers")
 	assert.Nil(t, res, "proxying should time out with all slow peers")
+	assert.Equal(t, "", peer, "peer should be empty if proxying timed out")
 }
 
 func TestProxyErrors(t *testing.T) {
-	w := httptest.NewRecorder()
 	errorPeer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)
 	}))
@@ -151,7 +159,9 @@ func TestProxyErrors(t *testing.T) {
 	}
 
 	r, _ := http.NewRequest("GET", "http://localhost", nil)
-	res, err := proxyTestVersion.proxy(w, r, peers)
+	res, peer, err := proxyTestVersion.proxy(r, peers)
+
 	assert.Equal(t, errNoAvailablePeers, err, "proxying should return errNoAvailablePeers if all error")
 	assert.Nil(t, res, "proxying should return errNoAvailablePeers if all error")
+	assert.Equal(t, "", peer, "peer should be empty if proxying timed out")
 }

--- a/serve.go
+++ b/serve.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"io"
+	"log"
+	"math/rand"
+	"net/http"
+	"strconv"
+
+	"github.com/stripe/sequins/blocks"
+)
+
+// serveKey is the entrypoint for incoming HTTP requests. It looks up the value
+// locally, for, failing that, asks a peer that has it. If the request was
+// already proxied to us, it is not proxied further.
+func (vs *version) serveKey(w http.ResponseWriter, r *http.Request, key string) {
+	// If we don't have any data for this version at all, that's a 404.
+	if vs.numPartitions == 0 {
+		vs.serveNotFound(w)
+		return
+	}
+
+	partition, alternatePartition := blocks.KeyPartition(key, vs.numPartitions)
+	bs := vs.getBlockStore()
+	if bs != nil && (vs.hasPartition(partition) || vs.hasPartition(alternatePartition)) {
+		record, err := bs.Get(key)
+		if err != nil {
+			vs.serveError(w, key, err)
+			return
+		}
+
+		vs.serveLocal(w, key, record)
+	} else if r.URL.Query().Get("proxy") == "" {
+		vs.serveProxied(w, r, key, partition, alternatePartition)
+	} else {
+		vs.serveError(w, key, errProxiedIncorrectly)
+	}
+}
+
+func (vs *version) serveLocal(w http.ResponseWriter, key string, record *blocks.Record) {
+	if record == nil {
+		vs.serveNotFound(w)
+		return
+	}
+
+	defer record.Close()
+	w.Header().Set(versionHeader, vs.name)
+	w.Header().Set("Content-Length", strconv.FormatUint(record.ValueLen, 10))
+	w.Header().Set("Last-Modified", vs.created.UTC().Format(http.TimeFormat))
+	_, err := io.Copy(w, record)
+	if err != nil {
+		// We already wrote a 200 OK, so not much we can do here except log.
+		log.Printf("Error streaming response for /%s/%s (version %s): %s", vs.db, key, vs.name)
+	}
+}
+
+func (vs *version) serveProxied(w http.ResponseWriter, r *http.Request,
+	key string, partition, alternatePartition int) {
+
+	// Shuffle the peers, so we try them in a random order.
+	// TODO: We don't want to blacklist nodes, but we can weight them lower
+	peers := shuffle(vs.partitions.getPeers(partition))
+	if len(peers) == 0 {
+		log.Printf("No peers available for /%s/%s (version %s)", vs.db, key, vs.name)
+		w.WriteHeader(http.StatusBadGateway)
+		return
+	}
+
+	resp, peer, err := vs.proxy(r, peers)
+	if err == nil && resp.StatusCode == 404 && alternatePartition != partition {
+		log.Println("Trying alternate partition for pathological key", key)
+
+		resp.Body.Close()
+		alternatePeers := shuffle(vs.partitions.getPeers(alternatePartition))
+		resp, peer, err = vs.proxy(r, alternatePeers)
+	}
+
+	if err == errNoAvailablePeers {
+		// Either something is wrong with sharding, or all peers errored for some
+		// other reason. 502
+		log.Printf("No peers available for /%s/%s (version %s)", vs.db, key, vs.name)
+		w.WriteHeader(http.StatusBadGateway)
+		return
+	} else if err == errProxyTimeout {
+		// All of our peers failed us. 504.
+		log.Printf("All peers timed out for /%s/%s (version %s)", vs.db, key, vs.name)
+		w.WriteHeader(http.StatusGatewayTimeout)
+		return
+	} else if err != nil {
+		// Some other error. 500.
+		vs.serveError(w, key, err)
+		return
+	}
+
+	// Proxying can produce inconsistent versions if something is broken. Use the
+	// one the peer set.
+	w.Header().Set(versionHeader, resp.Header.Get(versionHeader))
+	w.Header().Set(proxyHeader, peer)
+	w.Header().Set("Content-Length", resp.Header.Get("Content-Length"))
+	w.Header().Set("Last-Modified", vs.created.UTC().Format(http.TimeFormat))
+	w.WriteHeader(resp.StatusCode)
+
+	// TODO: Apparently in 1.7 the client always asks for gzip by default. If our
+	// client asks for gzip too, we should be able to pass through without
+	// decompressing.
+	defer resp.Body.Close()
+	_, err = io.Copy(w, resp.Body)
+	if err != nil {
+		// We already wrote a 200 OK, so not much we can do here except log.
+		log.Printf("Error copying response from peer for /%s/%s (version %s): %s", vs.db, key, vs.name)
+	}
+}
+
+func (vs *version) serveNotFound(w http.ResponseWriter) {
+	w.Header().Set(versionHeader, vs.name)
+	w.WriteHeader(http.StatusNotFound)
+}
+
+func (vs *version) serveError(w http.ResponseWriter, key string, err error) {
+	log.Printf("Error fetching value for /%s/%s: %s\n", vs.db, key, err)
+	w.WriteHeader(http.StatusInternalServerError)
+}
+
+func shuffle(vs []string) []string {
+	shuffled := make([]string, len(vs))
+	perm := rand.Perm(len(vs))
+	for i, v := range perm {
+		shuffled[v] = vs[i]
+	}
+
+	return shuffled
+}


### PR DESCRIPTION
Before this patch, we would buffer values into memory and then dump them out to the client. This is obviously not great for performance.

This PR fixes that, so we stream values either of disk or from peers. In the process, it cleans up some lurking issues with proxying:

 - Headers like `If-Not-Modified` weren't being passed back to peers
 - The `X-Sequins-Proxied-To` header wasn't always set correctly
 - The `X-Sequins-Version` header should be set to the peer's version, even if it's not the one we asked for

Unfortunately, this means we can't easily do http range requests. This PR removes that functionality rather than hack around it, as well as removing functionality for If-Not-Modified (which we could add back later with some more comprehensive thought towards caching and Etags).