### PR TITLE
Allow sequins to start up without data

### DIFF
--- a/main.go
+++ b/main.go
@@ -106,11 +106,9 @@ func main() {
 	}
 
 	// Do a basic test that the backend is valid.
-	dbs, err := s.backend.ListDBs()
+	_, err = s.backend.ListDBs()
 	if err != nil {
 		log.Fatalf("Error listing DBs from %s: %s", s.backend.DisplayPath(""), err)
-	} else if len(dbs) == 0 {
-		log.Fatal("No data found at ", s.backend.DisplayPath(""))
 	}
 
 	err = s.init()


### PR DESCRIPTION
This allows us to be a bit more user-friendly in the tutorial; users can start up sequins without any data, and then write data to it second.

r? @kitchen