### PR TITLE
Build a mechanism for GCing old zookeeper nodes

### DIFF
--- a/partitions.go
+++ b/partitions.go
@@ -48,11 +48,6 @@ func watchPartitions(zkWatcher *zkWatcher, peers *peers, db, version string, num
 		noneMissing:   make(chan bool),
 	}
 
-	// Create the partitions path we're going to watch, in case no one has done
-	// that yet.
-	p.zkPath = path.Join("partitions", db, version)
-	zkWatcher.createPath(p.zkPath)
-
 	updates, _ := zkWatcher.watchChildren(p.zkPath)
 	p.updateRemotePartitions(<-updates)
 	go p.sync(updates)

--- a/peers.go
+++ b/peers.go
@@ -42,7 +42,6 @@ func watchPeers(zkWatcher *zkWatcher, shardID, address string) *peers {
 		resetConvergenceTimer: make(chan bool),
 	}
 
-	zkWatcher.createPath("nodes")
 	node := path.Join("nodes", fmt.Sprintf("%s@%s", p.shardID, p.address))
 	zkWatcher.createEphemeral(node)
 

--- a/sequins.go
+++ b/sequins.go
@@ -119,6 +119,8 @@ func (s *sequins) initCluster() error {
 		return err
 	}
 
+	go zkWatcher.triggerCleanup()
+
 	hostname := s.config.Sharding.AdvertisedHostname
 	if hostname == "" {
 		hostname, err = os.Hostname()
@@ -259,6 +261,11 @@ func (s *sequins) refreshAll() {
 	}
 
 	s.dbsLock.RUnlock()
+
+	// Cleanup any zkNodes for deleted versions and dbs.
+	if s.zkWatcher != nil {
+		s.zkWatcher.triggerCleanup()
+	}
 }
 
 func (s *sequins) refresh(db *db) {

--- a/zk_watcher.go
+++ b/zk_watcher.go
@@ -182,15 +182,15 @@ Reconnect:
 				log.Println("Error reconnecting to zookeeper:", err)
 				continue Reconnect
 			}
+
+			// Every time we connect, reset watches and recreate ephemeral nodes.
+			err = w.runHooks()
+			if err != nil {
+				log.Println("Error running zookeeper hooks:", err)
+				continue Reconnect
+			}
 		} else {
 			first = false
-		}
-
-		// Every time we connect, reset watches and recreate ephemeral nodes.
-		err := w.runHooks()
-		if err != nil {
-			log.Println("Error running zookeeper hooks:", err)
-			continue Reconnect
 		}
 
 		select {

--- a/zk_watcher.go
+++ b/zk_watcher.go
@@ -256,6 +256,9 @@ func (w *zkWatcher) watchChildren(node string) (chan []string, chan bool) {
 	err := w.hookWatchChildren(node, wn)
 	if err != nil {
 		sendErr(w.errs, err)
+		go func() {
+			<-cancel
+		}()
 	}
 
 	return updates, disconnected

--- a/zk_watcher_test.go
+++ b/zk_watcher_test.go
@@ -103,9 +103,6 @@ func TestZKWatcher(t *testing.T) {
 	defer w.close()
 	defer tzk.close()
 
-	err := w.createPath("/foo")
-	require.NoError(t, err, "createPath should work")
-
 	updates, _ := w.watchChildren("/foo")
 	go func() {
 		w.createEphemeral("/foo/bar")
@@ -122,9 +119,6 @@ func TestZKWatcherReconnect(t *testing.T) {
 	w, tzk := connectZookeeperTest(t)
 	defer w.close()
 	defer tzk.close()
-
-	err := w.createPath("/foo")
-	require.NoError(t, err, "createPath should work")
 
 	updates, _ := w.watchChildren("/foo")
 	go func() {
@@ -144,9 +138,6 @@ func TestZKWatchesCanceled(t *testing.T) {
 	defer w.close()
 	defer tzk.close()
 
-	err := w.createPath("/foo")
-	require.NoError(t, err, "createPath should work")
-
 	w.watchChildren("/foo")
 
 	for i := 0; i < 3; i++ {
@@ -160,9 +151,6 @@ func TestZKRemoveWatch(t *testing.T) {
 	w, tzk := connectZookeeperTest(t)
 	defer w.close()
 	defer tzk.close()
-
-	err := w.createPath("/foo")
-	require.NoError(t, err, "createPath should work")
 
 	updates, disconnected := w.watchChildren("/foo")
 


### PR DESCRIPTION
Currently, we leak a non-ephemeral znode for every version of every database. This isn't *that* many, but it's kinda annoying and definitely unhygienic. 

However, we can't just go around arbitrarily deleting empty znodes, because that's racy when it comes to other nodes; they could be trying to create an ephemeral node rooted at the node we're deleting. To avoid this, this PR adds some retry logic and creating and watching that, if it needs to, also creates the parents of the nodes.

Finally, this PR fixes one possible deadlock I encountered while poking at this code.

r? @kitchen 