### PR TITLE
Refactor upgrade and build flows

### DIFF
--- a/blocks/block.go
+++ b/blocks/block.go
@@ -29,7 +29,7 @@ type Block struct {
 	sync.RWMutex
 }
 
-func loadBlock(storePath string, manifest blockManifest) (*Block, error) {
+func loadBlock(storePath string, manifest BlockManifest) (*Block, error) {
 	b := &Block{
 		ID:        manifest.ID,
 		Name:      manifest.Name,
@@ -70,8 +70,8 @@ func (b *Block) Close() {
 	b.sparkeyReader.Close()
 }
 
-func (b *Block) manifest() blockManifest {
-	return blockManifest{
+func (b *Block) manifest() BlockManifest {
+	return BlockManifest{
 		ID:        b.ID,
 		Name:      b.Name,
 		Partition: b.Partition,

--- a/blocks/block_store_test.go
+++ b/blocks/block_store_test.go
@@ -12,7 +12,7 @@ func testBlockStoreCompression(t *testing.T, compression Compression) {
 	tmpDir, err := ioutil.TempDir("", "sequins-test-")
 	require.NoError(t, err, "creating a test tmpdir")
 
-	bs := New(tmpDir, 2, nil, compression, 8192)
+	bs := New(tmpDir, 2, compression, 8192)
 
 	err = bs.Add([]byte("Alice"), []byte("Practice"))
 	require.NoError(t, err, "adding keys to the block store")
@@ -20,7 +20,7 @@ func testBlockStoreCompression(t *testing.T, compression Compression) {
 	err = bs.Add([]byte("Bob"), []byte("Hope"))
 	require.NoError(t, err, "adding keys to the block store")
 
-	err = bs.Save()
+	err = bs.Save(nil)
 	require.NoError(t, err, "saving the manifest")
 	assert.Equal(t, 2, len(bs.Blocks), "should have the correct number of blocks")
 
@@ -35,7 +35,7 @@ func testBlockStoreCompression(t *testing.T, compression Compression) {
 	// Close the index, then load it from the manifest.
 	bs.Close()
 
-	bs, err = NewFromManifest(tmpDir, nil)
+	bs, _, err = NewFromManifest(tmpDir)
 	require.NoError(t, err, "loading from manifest")
 
 	assert.Equal(t, 2, len(bs.Blocks), "should have the correct number of blocks")

--- a/blocks/block_store_test.go
+++ b/blocks/block_store_test.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/colinmarc/sequencefile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -15,11 +14,11 @@ func testBlockStoreCompression(t *testing.T, compression Compression) {
 
 	bs := New(tmpDir, 2, nil, compression, 8192)
 
-	sf, err := sequencefile.Open("../test/test.sequencefile")
-	require.NoError(t, err, "opening a test file")
+	err = bs.Add([]byte("Alice"), []byte("Practice"))
+	require.NoError(t, err, "adding keys to the block store")
 
-	err = bs.AddFile(sf, 0)
-	require.NoError(t, err, "adding the file to the block store")
+	err = bs.Add([]byte("Bob"), []byte("Hope"))
+	require.NoError(t, err, "adding keys to the block store")
 
 	err = bs.Save()
 	require.NoError(t, err, "saving the manifest")

--- a/blocks/block_writer.go
+++ b/blocks/block_writer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"os"
 	"path/filepath"
 
 	"github.com/bsm/go-sparkey"
@@ -35,7 +36,7 @@ func newBlock(storePath string, partition int, compression Compression, blockSiz
 	options := &sparkey.Options{Compression: c, CompressionBlockSize: blockSize}
 	sparkeyWriter, err := sparkey.CreateLogWriter(path, options)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("initializing block %s: %s", path, err)
 	}
 
 	bw := &blockWriter{
@@ -99,4 +100,8 @@ func (bw *blockWriter) save() (*Block, error) {
 
 func (bw *blockWriter) close() {
 	bw.sparkeyWriter.Close()
+}
+
+func (bw *blockWriter) delete() {
+	os.Remove(bw.path)
 }

--- a/blocks/hashcode.go
+++ b/blocks/hashcode.go
@@ -16,9 +16,9 @@ func hashCode(b []byte) int32 {
 // match the way hadoop shuffles keys to reducers. It sometimes returns a second
 // partition where the key may be; see the comment for
 // alternatePathologicalKeyPartition below.
-func KeyPartition(key string, totalPartitions int) (int, int) {
-	hc := hashCode([]byte(key))
-	normal := int(hashCode([]byte(key))&math.MaxInt32) % totalPartitions
+func KeyPartition(key []byte, totalPartitions int) (int, int) {
+	hc := hashCode(key)
+	normal := int(hashCode(key)&math.MaxInt32) % totalPartitions
 	alternate := alternatePathologicalKeyPartition(hc, totalPartitions)
 
 	if alternate == -1 {

--- a/blocks/hashcode_test.go
+++ b/blocks/hashcode_test.go
@@ -53,15 +53,15 @@ func TestJavaHashCode(t *testing.T) {
 // under normal partitioning, but "fol" and the pathological key would be sorted
 // together under cascading partitioning.
 func TestKeyPartition(t *testing.T) {
-	partition, alternate := KeyPartition("bar", 20)
+	partition, alternate := KeyPartition([]byte("bar"), 20)
 	assert.Equal(t, 19, partition)
 	assert.Equal(t, 19, alternate)
 
-	partition, alternate = KeyPartition("fol", 20)
+	partition, alternate = KeyPartition([]byte("fol"), 20)
 	assert.Equal(t, 11, partition)
 	assert.Equal(t, 11, alternate)
 
-	partition, alternate = KeyPartition("\x70\x17\xad\x78\x8c\x5e\x85\xf1\x43\x27\xf8\x67", 20)
+	partition, alternate = KeyPartition([]byte{0x70, 0x17, 0xad, 0x78, 0x8c, 0x5e, 0x85, 0xf1, 0x43, 0x27, 0xf8, 0x67}, 20)
 	assert.Equal(t, 19, partition)
 	assert.Equal(t, 11, alternate)
 }

--- a/blocks/manifest.go
+++ b/blocks/manifest.go
@@ -11,16 +11,16 @@ const manifestVersion = 3
 
 var ErrWrongVersion = errors.New("wrong manifest version")
 
-type manifest struct {
+type Manifest struct {
 	Version            int             `json:"version"`
-	Blocks             []blockManifest `json:"blocks"`
+	Blocks             []BlockManifest `json:"blocks"`
 	NumPartitions      int             `json:"num_partitions"`
-	SelectedPartitions []int           `json:"selected_partitions,omitempty"`
+	SelectedPartitions []int           `json:"selected_partitions"`
 	Compression        Compression     `json:"compression"`
 	BlockSize          int             `json:"block_size"`
 }
 
-type blockManifest struct {
+type BlockManifest struct {
 	ID        string `json:"id"`
 	Name      string `json:"name"`
 	Partition int    `json:"partition"`
@@ -29,8 +29,8 @@ type blockManifest struct {
 	MaxKey    []byte `json:"max_key"`
 }
 
-func readManifest(path string) (manifest, error) {
-	m := manifest{}
+func readManifest(path string) (Manifest, error) {
+	m := Manifest{}
 
 	reader, err := os.Open(path)
 	if err != nil {
@@ -57,10 +57,18 @@ func readManifest(path string) (manifest, error) {
 		m.Compression = SnappyCompression
 	}
 
+	// TODO: this too
+	if m.SelectedPartitions == nil {
+		m.SelectedPartitions = make([]int, m.NumPartitions)
+		for i := range m.SelectedPartitions {
+			m.SelectedPartitions[i] = i
+		}
+	}
+
 	return m, nil
 }
 
-func writeManifest(path string, m manifest) error {
+func writeManifest(path string, m Manifest) error {
 	bytes, err := json.Marshal(m)
 	if err != nil {
 		return err

--- a/build.go
+++ b/build.go
@@ -30,6 +30,10 @@ func (vs *version) build(files []string) error {
 
 	if len(files) == 0 {
 		log.Println("Version", vs.name, "of", vs.db, "has no data. Loading it anyway.")
+		if vs.partitions == nil {
+			close(vs.ready)
+		}
+
 		return nil
 	} else if len(files) != vs.numPartitions {
 		log.Printf("Number of files under %s changed (%d vs %d)",
@@ -63,6 +67,8 @@ func (vs *version) build(files []string) error {
 	vs.blockStore = blockStore
 	if vs.partitions != nil {
 		vs.partitions.updateLocalPartitions(vs.selectedLocalPartitions)
+	} else {
+		close(vs.ready)
 	}
 
 	return nil

--- a/build.go
+++ b/build.go
@@ -138,7 +138,7 @@ func (vs *version) addFile(bs *blocks.BlockStore, file string) error {
 		return fmt.Errorf("reading %s: %s", disp, err)
 	}
 	defer stream.Close()
-	
+
 	sf := sequencefile.NewReader(bufio.NewReader(stream))
 	err = sf.ReadHeader()
 	if err != nil {

--- a/build.go
+++ b/build.go
@@ -14,124 +14,97 @@ import (
 )
 
 var (
-	errFilesChanged   = errors.New("the list of remote files changed while building")
 	errWrongPartition = errors.New("the file is cleanly partitioned, but doesn't contain a partition we want")
+	errCanceled       = errors.New("build canceled")
 )
 
-// build prepares the version, blocking until all local partitions are ready,
-// then returns it. If onlyFromManifest is true, it will only load data on local
-// disk from a manifest, and fail otherwise.
-func (vs *version) build(files []string) error {
-	if vs.blockStore != nil {
-		return nil
-	} else if len(vs.selectedLocalPartitions) == 0 {
-		vs.partitions.updateLocalPartitions(nil)
-		return nil
+func (vs *version) build() {
+	// Grab the lock for this version, and check that the previous holder didn't
+	// finish building.
+	vs.buildLock.Lock()
+	defer vs.buildLock.Unlock()
+	if vs.built {
+		return
 	}
 
-	if len(files) == 0 {
-		log.Println("Version", vs.name, "of", vs.db, "has no data. Loading it anyway.")
-		return nil
-	} else if len(files) != vs.numPartitions {
-		log.Printf("Number of files under %s changed (%d vs %d)",
-			vs.sequins.backend.DisplayPath(vs.db, vs.name), len(files), vs.numPartitions)
-		return errFilesChanged
+	// Then the db-wide lock, and check that a newer version didn't obsolete us.
+	vs.db.buildLock.Lock()
+	defer vs.db.buildLock.Unlock()
+	select {
+	case <-vs.cancel:
+		return
+	default:
 	}
 
-	log.Println("Loading", vs.db, "version", vs.name, "from",
-		vs.sequins.backend.DisplayPath(vs.db, vs.name), "into local directory", vs.path)
-
-	blockStore, err := vs.createStore(files)
-	if err != nil {
-		return err
+	// Finally, grab one of the global build locks (if the lock exists).
+	if vs.sequins.buildLock != nil {
+		lock := vs.sequins.buildLock.Lock()
+		defer close(lock)
 	}
 
-	// Verify that the list of files stayed the same. If files do not match,
-	// discard the new blockstore in order to prevent the manifest from updating.
-	newFiles, err := vs.sequins.backend.ListFiles(vs.db, vs.name)
-	if err != nil {
-		return err
-	} else {
-		if vs.compareFileSets(files, newFiles) {
-			blockStore.Close()
-			blockStore.Delete()
-			return errFilesChanged
-		}
+	partitions := vs.partitions.needed()
+	if len(partitions) == 0 {
+		vs.built = true
+		return
 	}
 
-	vs.blockStoreLock.Lock()
-	defer vs.blockStoreLock.Unlock()
-	vs.blockStore = blockStore
-	vs.partitions.updateLocalPartitions(vs.selectedLocalPartitions)
-	return nil
-}
+	log.Println("Loading", len(partitions), "partitions of", vs.db.name, "version", vs.name,
+		"from", vs.sequins.backend.DisplayPath(vs.db.name, vs.name))
 
-func (vs *version) compareFileSets(oldFiles, newFiles []string) bool {
-	setOld := make(map[string]bool, len(oldFiles))
-	setNew := make(map[string]bool, len(newFiles))
-	different := false
-
-	if len(oldFiles) != len(newFiles) {
-		log.Printf("Number of files under %s changed (%d vs %d)",
-			vs.sequins.backend.DisplayPath(vs.db, vs.name), len(oldFiles), len(newFiles))
-		different = true
-	}
-
-	for _, f := range oldFiles {
-		setOld[f] = true
-	}
-
-	for _, f := range newFiles {
-		setNew[f] = true
-		if !setOld[f] {
-			log.Println("New file:", vs.sequins.backend.DisplayPath(vs.db, vs.name, f))
-			different = true
-		}
-	}
-
-	for _, f := range oldFiles {
-		if !setNew[f] {
-			log.Println("Missing file:", vs.sequins.backend.DisplayPath(vs.db, vs.name, f))
-			different = true
-		}
-	}
-
-	return different
-}
-
-// TODO: parallelize files
-
-func (vs *version) createStore(files []string) (*blocks.BlockStore, error) {
-	if _, err := os.Stat(vs.path); err == nil {
-		log.Println("Clearing local directory", vs.path)
-	}
-
-	os.RemoveAll(vs.path)
+	// We create the directory right before we load data into it, so we don't
+	// leave empty directories laying around.
 	err := os.MkdirAll(vs.path, 0755|os.ModeDir)
-	if err != nil {
-		return nil, fmt.Errorf("error creating local storage directory: %s", err)
+	if err != nil && !os.IsExist(err) {
+		log.Printf("Error initializing version %s of %s: %s", vs.name, vs.db.name, err)
+		vs.setState(versionError)
+		return
 	}
 
-	blockStore := blocks.New(vs.path, vs.numPartitions, vs.selectedLocalPartitions,
-		vs.sequins.config.Storage.Compression, vs.sequins.config.Storage.BlockSize)
-	for _, file := range files {
-		err := vs.addFile(blockStore, file)
+	err = vs.addFiles(partitions)
+	if err != nil {
+		if err != errCanceled {
+			log.Printf("Error building version %s of %s: %s", vs.name, vs.db.name, err)
+			vs.setState(versionError)
+		}
+
+		vs.blockStore.Revert()
+		return
+	}
+
+	vs.partitions.updateLocalPartitions(partitions)
+	vs.built = true
+}
+
+// addFiles adds the given files to the block store, selecting only the
+// given partitions.
+func (vs *version) addFiles(partitions map[int]bool) error {
+	if len(vs.files) == 0 {
+		log.Println("Version", vs.name, "of", vs.db.name, "has no data. Loading it anyway.")
+		return nil
+	}
+
+	// TODO: parallelize files?
+	for _, file := range vs.files {
+		select {
+		case <-vs.cancel:
+			return errCanceled
+		default:
+		}
+
+		err := vs.addFile(file, partitions)
 		if err != nil {
-			blockStore.Close()
-			blockStore.Delete()
-			return nil, err
+			return err
 		}
 	}
 
-	blockStore.Save()
-	return blockStore, nil
+	return vs.blockStore.Save(vs.partitions.selected)
 }
 
-func (vs *version) addFile(bs *blocks.BlockStore, file string) error {
-	disp := vs.sequins.backend.DisplayPath(vs.db, vs.name, file)
+func (vs *version) addFile(file string, partitions map[int]bool) error {
+	disp := vs.sequins.backend.DisplayPath(vs.db.name, vs.name, file)
 	log.Println("Reading records from", disp)
 
-	stream, err := vs.sequins.backend.Open(vs.db, vs.name, file)
+	stream, err := vs.sequins.backend.Open(vs.db.name, vs.name, file)
 	if err != nil {
 		return fmt.Errorf("reading %s: %s", disp, err)
 	}
@@ -143,7 +116,7 @@ func (vs *version) addFile(bs *blocks.BlockStore, file string) error {
 		return fmt.Errorf("reading header from %s: %s", disp, err)
 	}
 
-	err = vs.addFileKeys(bs, sf)
+	err = vs.addFileKeys(sf, partitions)
 	if err == errWrongPartition {
 		log.Println("Skipping", disp, "because it contains no relevant partitions")
 	} else if err != nil {
@@ -153,7 +126,7 @@ func (vs *version) addFile(bs *blocks.BlockStore, file string) error {
 	return nil
 }
 
-func (vs *version) addFileKeys(bs *blocks.BlockStore, reader *sequencefile.Reader) error {
+func (vs *version) addFileKeys(reader *sequencefile.Reader, partitions map[int]bool) error {
 	throttle := vs.sequins.config.ThrottleLoads.Duration
 	canAssumePartition := true
 	assumedPartition := -1
@@ -189,10 +162,10 @@ func (vs *version) addFileKeys(bs *blocks.BlockStore, reader *sequencefile.Reade
 			}
 		}
 
-		// Once we see 5000 keys from the same partition, and it's a partition we
-		// don't want, it's safe to assume the whole file is like that, and we can
-		// skip the rest.
-		if vs.selectedLocalPartitions != nil && !vs.selectedLocalPartitions[partition] {
+		if !partitions[partition] {
+			// Once we see 5000 keys from the same partition, and it's a partition we
+			// don't want, it's safe to assume the whole file is like that, and we can
+			// skip the rest.
 			if canAssumePartition && assumedFor > 5000 {
 				return errWrongPartition
 			}
@@ -200,7 +173,10 @@ func (vs *version) addFileKeys(bs *blocks.BlockStore, reader *sequencefile.Reade
 			continue
 		}
 
-		bs.Add(key, value)
+		err = vs.blockStore.Add(key, value)
+		if err != nil {
+			return err
+		}
 	}
 
 	if reader.Err() != nil {

--- a/build.go
+++ b/build.go
@@ -6,13 +6,17 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/colinmarc/sequencefile"
 
 	"github.com/stripe/sequins/blocks"
 )
 
-var errFilesChanged = errors.New("the list of remote files changed while building")
+var (
+	errFilesChanged   = errors.New("the list of remote files changed while building")
+	errWrongPartition = errors.New("the file is cleanly partitioned, but doesn't contain a partition we want")
+)
 
 // build prepares the version, blocking until all local partitions are ready,
 // then returns it. If onlyFromManifest is true, it will only load data on local
@@ -20,27 +24,23 @@ var errFilesChanged = errors.New("the list of remote files changed while buildin
 func (vs *version) build(files []string) error {
 	if vs.blockStore != nil {
 		return nil
+	} else if vs.selectedLocalPartitions != nil && len(vs.selectedLocalPartitions) == 0 {
+		return nil
 	}
 
 	if len(files) == 0 {
 		log.Println("Version", vs.name, "of", vs.db, "has no data. Loading it anyway.")
 		return nil
-	}
-
-	var local map[int]bool
-	if vs.sequins.peers != nil {
-		local = vs.partitions.pickLocalPartitions()
-		if len(local) == 0 {
-			log.Println("All valid partitions for", vs.db, "version", vs.name,
-				"are already spoken for. Consider increasing the replication level.")
-			return nil
-		}
+	} else if len(files) != vs.numPartitions {
+		log.Printf("Number of files under %s changed (%d vs %d)",
+			vs.sequins.backend.DisplayPath(vs.db, vs.name), len(files), vs.numPartitions)
+		return errFilesChanged
 	}
 
 	log.Println("Loading", vs.db, "version", vs.name, "from",
 		vs.sequins.backend.DisplayPath(vs.db, vs.name), "into local directory", vs.path)
 
-	blockStore, err := vs.createStore(files, local)
+	blockStore, err := vs.createStore(files)
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func (vs *version) build(files []string) error {
 	defer vs.blockStoreLock.Unlock()
 	vs.blockStore = blockStore
 	if vs.partitions != nil {
-		vs.partitions.updateLocalPartitions(local)
+		vs.partitions.updateLocalPartitions(vs.selectedLocalPartitions)
 	}
 
 	return nil
@@ -103,7 +103,7 @@ func (vs *version) compareFileSets(oldFiles, newFiles []string) bool {
 
 // TODO: parallelize files
 
-func (vs *version) createStore(files []string, partitions map[int]bool) (*blocks.BlockStore, error) {
+func (vs *version) createStore(files []string) (*blocks.BlockStore, error) {
 	if _, err := os.Stat(vs.path); err == nil {
 		log.Println("Clearing local directory", vs.path)
 	}
@@ -114,7 +114,7 @@ func (vs *version) createStore(files []string, partitions map[int]bool) (*blocks
 		return nil, fmt.Errorf("error creating local storage directory: %s", err)
 	}
 
-	blockStore := blocks.New(vs.path, len(files), partitions,
+	blockStore := blocks.New(vs.path, vs.numPartitions, vs.selectedLocalPartitions,
 		vs.sequins.config.Storage.Compression, vs.sequins.config.Storage.BlockSize)
 	for _, file := range files {
 		err := vs.addFile(blockStore, file)
@@ -145,12 +145,101 @@ func (vs *version) addFile(bs *blocks.BlockStore, file string) error {
 		return fmt.Errorf("reading header from %s: %s", disp, err)
 	}
 
-	err = bs.AddFile(sf, vs.sequins.config.ThrottleLoads.Duration)
-	if err == blocks.ErrWrongPartition {
+	err = vs.addFileKeys(bs, sf)
+	if err == errWrongPartition {
 		log.Println("Skipping", disp, "because it contains no relevant partitions")
 	} else if err != nil {
 		return fmt.Errorf("reading %s: %s", disp, err)
 	}
 
 	return nil
+}
+
+func (vs *version) addFileKeys(bs *blocks.BlockStore, reader *sequencefile.Reader) error {
+	throttle := vs.sequins.config.ThrottleLoads.Duration
+	canAssumePartition := true
+	assumedPartition := -1
+	assumedFor := 0
+
+	for reader.Scan() {
+		if throttle != 0 {
+			time.Sleep(throttle)
+		}
+
+		key, value, err := unwrapKeyValue(reader)
+		if err != nil {
+			return err
+		}
+
+		partition, alternatePartition := blocks.KeyPartition(key, vs.numPartitions)
+
+		// If we see the same partition (which is based on the hash) for the first
+		// 5000 keys, it's safe to assume that this file only contains that
+		// partition. This is often the case if the data has been shuffled by the
+		// output key in a way that aligns with our own partitioning scheme.
+		if canAssumePartition {
+			if assumedPartition == -1 {
+				assumedPartition = partition
+			} else if partition != assumedPartition {
+				if alternatePartition == assumedPartition {
+					partition = alternatePartition
+				} else {
+					canAssumePartition = false
+				}
+			} else {
+				assumedFor += 1
+			}
+		}
+
+		// Once we see 5000 keys from the same partition, and it's a partition we
+		// don't want, it's safe to assume the whole file is like that, and we can
+		// skip the rest.
+		if vs.selectedLocalPartitions != nil && !vs.selectedLocalPartitions[partition] {
+			if canAssumePartition && assumedFor > 5000 {
+				return errWrongPartition
+			}
+
+			continue
+		}
+
+		bs.Add(key, value)
+	}
+
+	if reader.Err() != nil {
+		return reader.Err()
+	}
+
+	return nil
+}
+
+// unwrapKeyValue correctly prepares a key and value for storage, depending on
+// how they are serialized in the original file; namely, BytesWritable and Text
+// keys and values are unwrapped.
+func unwrapKeyValue(reader *sequencefile.Reader) (key []byte, value []byte, err error) {
+	// sequencefile.Text or sequencefile.BytesWritable can panic if the data is corrupted.
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("sequencefile: record deserialization failed: %s", r)
+		}
+	}()
+
+	switch reader.Header.KeyClassName {
+	case sequencefile.BytesWritableClassName:
+		key = sequencefile.BytesWritable(reader.Key())
+	case sequencefile.TextClassName:
+		key = []byte(sequencefile.Text(reader.Key()))
+	default:
+		key = reader.Key()
+	}
+
+	switch reader.Header.ValueClassName {
+	case sequencefile.BytesWritableClassName:
+		value = sequencefile.BytesWritable(reader.Value())
+	case sequencefile.TextClassName:
+		value = []byte(sequencefile.Text(reader.Value()))
+	default:
+		value = reader.Value()
+	}
+
+	return
 }

--- a/build.go
+++ b/build.go
@@ -24,16 +24,13 @@ var (
 func (vs *version) build(files []string) error {
 	if vs.blockStore != nil {
 		return nil
-	} else if vs.selectedLocalPartitions != nil && len(vs.selectedLocalPartitions) == 0 {
+	} else if len(vs.selectedLocalPartitions) == 0 {
+		vs.partitions.updateLocalPartitions(nil)
 		return nil
 	}
 
 	if len(files) == 0 {
 		log.Println("Version", vs.name, "of", vs.db, "has no data. Loading it anyway.")
-		if vs.partitions == nil {
-			close(vs.ready)
-		}
-
 		return nil
 	} else if len(files) != vs.numPartitions {
 		log.Printf("Number of files under %s changed (%d vs %d)",
@@ -65,12 +62,7 @@ func (vs *version) build(files []string) error {
 	vs.blockStoreLock.Lock()
 	defer vs.blockStoreLock.Unlock()
 	vs.blockStore = blockStore
-	if vs.partitions != nil {
-		vs.partitions.updateLocalPartitions(vs.selectedLocalPartitions)
-	} else {
-		close(vs.ready)
-	}
-
+	vs.partitions.updateLocalPartitions(vs.selectedLocalPartitions)
 	return nil
 }
 

--- a/db.go
+++ b/db.go
@@ -72,7 +72,15 @@ func (db *db) backfillVersions() error {
 		}
 
 		version := newVersion(db.sequins, db.localPath(v), db.name, v, len(files))
-		if version.ready() {
+		var ready bool
+		select {
+		case <-version.ready:
+			ready = true
+		default:
+			ready = false
+		}
+
+		if ready {
 			// The version is complete, most likely because our peers have it. We
 			// can switch to it right away, and build any (possibly underreplicated)
 			// partitions in the background.
@@ -91,7 +99,9 @@ func (db *db) backfillVersions() error {
 
 				log.Println("Finished building version", v, "of", db.name)
 				version.setState(versionAvailable)
-				version.advertiseAndWait()
+				if version.partitions != nil {
+					version.partitions.advertisePartitions()
+				}
 			}()
 
 			break
@@ -163,21 +173,34 @@ func (db *db) switchVersion(version *version) {
 	db.mux.prepare(version)
 	version.setState(versionAvailable)
 
-	if version.ready() {
-		version.advertiseAndWait()
-		db.newVersions <- version
-	} else {
+	if version.partitions != nil {
+		// Advertise to peers that we have our partitions ready.
+		version.partitions.advertisePartitions()
+
+		// Wait for all our peers to be ready. All peers should all see that
+		// everything is ready at roughly the same time. If they switch before us,
+		// that's fine; the new version has been 'prepared' and we can serve it to
+		// peers (but not clients). If they switch after us, that's also fine,
+		// since we'll keep the old version around for a bit before deleting it.
 		go func() {
-			// Wait for all our peers to be ready. All peers should all see that
-			// everything is ready at roughly the same time. If they switch before us,
-			// that's fine; the new version has been 'prepared' and we can serve it to
-			// peers (but not clients). If they switch after us, that's also fine,
-			// since we'll keep the old version around for a bit before deleting it.
-			success := version.advertiseAndWait()
-			if success {
-				db.newVersions <- version
+			t := time.NewTicker(10 * time.Second)
+
+			for {
+				select {
+				case <-version.closed:
+					return
+				case <-version.ready:
+					db.newVersions <- version
+					return
+				case <-t.C:
+				}
+
+				log.Printf("Waiting for all partitions of %s version %s to be available (missing %d)",
+					db.name, version.name, version.partitions.missing())
 			}
 		}()
+	} else {
+		db.newVersions <- version
 	}
 }
 

--- a/multilock/multilock.go
+++ b/multilock/multilock.go
@@ -1,0 +1,35 @@
+// package multilock provides a locking mechanism that can be locked by N
+// cilents simultaneously.
+package multilock
+
+type Multilock struct {
+	workers chan bool
+}
+
+func New(n int) *Multilock {
+	m := &Multilock{
+		workers: make(chan bool, n),
+	}
+
+	for i := 0; i < n; i++ {
+		m.workers <- true
+	}
+
+	return m
+}
+
+// Lock blocks until the lock is acquired, and returns a channel which must be
+// closed to release the lock. It ensures that only N clients hold the lock
+// overall, but makes no garauntee that locks are granted in the order they are
+// requested.
+func (m *Multilock) Lock() chan bool {
+	<-m.workers
+
+	l := make(chan bool)
+	go func() {
+		<-l
+		m.workers <- true
+	}()
+
+	return l
+}

--- a/multilock/multilock_test.go
+++ b/multilock/multilock_test.go
@@ -1,0 +1,42 @@
+package multilock
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestMultilock(t *testing.T) {
+	t.Parallel()
+
+	m := New(5)
+	wg := sync.WaitGroup{}
+	var v int32
+
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			l := m.Lock()
+			defer close(l)
+
+			// Check that only 5 goroutines hold the lock.
+			total := atomic.AddInt32(&v, 1)
+			if total > 5 {
+				t.Errorf("%d concurrent writers!", total)
+			}
+
+			// Ensure that goroutines pile up.
+			time.Sleep(1 * time.Millisecond)
+
+			total = atomic.AddInt32(&v, -1)
+			if total < 0 {
+				t.Error("more than 5 concurrent writers!")
+			}
+		}(i)
+	}
+
+	wg.Wait()
+}

--- a/multilock/multilock_test.go
+++ b/multilock/multilock_test.go
@@ -19,8 +19,8 @@ func TestMultilock(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 
-			l := m.Lock()
-			defer close(l)
+			m.Lock()
+			defer m.Unlock()
 
 			// Check that only 5 goroutines hold the lock.
 			total := atomic.AddInt32(&v, 1)

--- a/partitions.go
+++ b/partitions.go
@@ -243,11 +243,12 @@ func (p *partitions) partitionId(partition int) string {
 }
 
 func (p *partitions) close() {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
 	if p.peers != nil {
-		p.zkWatcher.removeWatch(p.zkPath)
 		p.unadvertisePartitions()
+
+		p.lock.Lock()
+		defer p.lock.Unlock()
+
+		p.zkWatcher.removeWatch(p.zkPath)
 	}
 }

--- a/serve.go
+++ b/serve.go
@@ -20,7 +20,7 @@ func (vs *version) serveKey(w http.ResponseWriter, r *http.Request, key string) 
 		return
 	}
 
-	partition, alternatePartition := blocks.KeyPartition(key, vs.numPartitions)
+	partition, alternatePartition := blocks.KeyPartition([]byte(key), vs.numPartitions)
 	bs := vs.getBlockStore()
 	if bs != nil && (vs.hasPartition(partition) || vs.hasPartition(alternatePartition)) {
 		record, err := bs.Get(key)

--- a/serve.go
+++ b/serve.go
@@ -21,9 +21,8 @@ func (vs *version) serveKey(w http.ResponseWriter, r *http.Request, key string) 
 	}
 
 	partition, alternatePartition := blocks.KeyPartition([]byte(key), vs.numPartitions)
-	bs := vs.getBlockStore()
-	if bs != nil && (vs.hasPartition(partition) || vs.hasPartition(alternatePartition)) {
-		record, err := bs.Get(key)
+	if vs.partitions.have(partition) || vs.partitions.have(alternatePartition) {
+		record, err := vs.blockStore.Get(key)
 		if err != nil {
 			vs.serveError(w, key, err)
 			return
@@ -50,7 +49,7 @@ func (vs *version) serveLocal(w http.ResponseWriter, key string, record *blocks.
 	_, err := io.Copy(w, record)
 	if err != nil {
 		// We already wrote a 200 OK, so not much we can do here except log.
-		log.Printf("Error streaming response for /%s/%s (version %s): %s", vs.db, key, vs.name, err)
+		log.Printf("Error streaming response for /%s/%s (version %s): %s", vs.db.name, key, vs.name, err)
 	}
 }
 
@@ -61,7 +60,7 @@ func (vs *version) serveProxied(w http.ResponseWriter, r *http.Request,
 	// TODO: We don't want to blacklist nodes, but we can weight them lower
 	peers := shuffle(vs.partitions.getPeers(partition))
 	if len(peers) == 0 {
-		log.Printf("No peers available for /%s/%s (version %s)", vs.db, key, vs.name)
+		log.Printf("No peers available for /%s/%s (version %s)", vs.db.name, key, vs.name)
 		w.WriteHeader(http.StatusBadGateway)
 		return
 	}
@@ -78,12 +77,12 @@ func (vs *version) serveProxied(w http.ResponseWriter, r *http.Request,
 	if err == errNoAvailablePeers {
 		// Either something is wrong with sharding, or all peers errored for some
 		// other reason. 502
-		log.Printf("No peers available for /%s/%s (version %s)", vs.db, key, vs.name)
+		log.Printf("No peers available for /%s/%s (version %s)", vs.db.name, key, vs.name)
 		w.WriteHeader(http.StatusBadGateway)
 		return
 	} else if err == errProxyTimeout {
 		// All of our peers failed us. 504.
-		log.Printf("All peers timed out for /%s/%s (version %s)", vs.db, key, vs.name)
+		log.Printf("All peers timed out for /%s/%s (version %s)", vs.db.name, key, vs.name)
 		w.WriteHeader(http.StatusGatewayTimeout)
 		return
 	} else if err != nil {
@@ -107,7 +106,7 @@ func (vs *version) serveProxied(w http.ResponseWriter, r *http.Request,
 	_, err = io.Copy(w, resp.Body)
 	if err != nil {
 		// We already wrote a 200 OK, so not much we can do here except log.
-		log.Printf("Error copying response from peer for /%s/%s (version %s): %s", vs.db, key, vs.name, err)
+		log.Printf("Error copying response from peer for /%s/%s (version %s): %s", vs.db.name, key, vs.name, err)
 	}
 }
 
@@ -117,7 +116,7 @@ func (vs *version) serveNotFound(w http.ResponseWriter) {
 }
 
 func (vs *version) serveError(w http.ResponseWriter, key string, err error) {
-	log.Printf("Error fetching value for /%s/%s: %s\n", vs.db, key, err)
+	log.Printf("Error fetching value for /%s/%s: %s\n", vs.db.name, key, err)
 	w.WriteHeader(http.StatusInternalServerError)
 }
 

--- a/status.go
+++ b/status.go
@@ -302,13 +302,13 @@ func (vs *version) status() versionStatus {
 	defer vs.stateLock.Unlock()
 
 	st := versionStatus{
-		Path:          vs.sequins.backend.DisplayPath(vs.db, vs.name),
+		Path:          vs.sequins.backend.DisplayPath(vs.db.name, vs.name),
 		NumPartitions: vs.numPartitions,
 		Nodes:         make(map[string]nodeVersionStatus),
 	}
 
-	partitions := make([]int, 0, len(vs.selectedLocalPartitions))
-	for p := range vs.selectedLocalPartitions {
+	partitions := make([]int, 0, len(vs.partitions.selected))
+	for p := range vs.partitions.selected {
 		partitions = append(partitions, p)
 	}
 
@@ -336,8 +336,10 @@ func (vs *version) setState(state versionState) {
 	vs.stateLock.Lock()
 	defer vs.stateLock.Unlock()
 
-	vs.state = state
-	if state == versionAvailable {
-		vs.available = time.Now()
+	if vs.state != versionError {
+		vs.state = state
+		if state == versionAvailable {
+			vs.available = time.Now()
+		}
 	}
 }

--- a/status.go
+++ b/status.go
@@ -275,75 +275,69 @@ func acceptsJSON(r *http.Request) bool {
 }
 
 func (db *db) status() dbStatus {
-	db.versionStatusLock.RLock()
-	defer db.versionStatusLock.RUnlock()
-
-	return copyDBStatus(dbStatus{Versions: db.versionStatus})
-}
-
-func (db *db) trackVersion(version *version, state versionState) {
-	db.versionStatusLock.Lock()
-	defer db.versionStatusLock.Unlock()
+	status := dbStatus{Versions: make(map[string]versionStatus)}
+	for _, vs := range db.mux.getAll() {
+		status.Versions[vs.name] = vs.status()
+	}
 
 	hostname := "localhost"
 	if db.sequins.peers != nil {
 		hostname = db.sequins.peers.address
 	}
 
-	st, ok := db.versionStatus[version.name]
-	if !ok {
-		st = versionStatus{
-			Path:          db.sequins.backend.DisplayPath(db.name, version.name),
-			NumPartitions: version.numPartitions,
-			Nodes:         make(map[string]nodeVersionStatus),
-		}
-
-		if version.partitions != nil {
-			st.TargetReplication = version.partitions.replication
-		}
-
-		partitions := make([]int, 0, len(version.selectedLocalPartitions))
-		for p := range version.selectedLocalPartitions {
-			partitions = append(partitions, p)
-		}
-
-		sort.Ints(partitions)
-		nodeStatus := nodeVersionStatus{
-			CreatedAt:  time.Now().UTC().Truncate(time.Second),
-			State:      state,
-			Partitions: partitions,
-		}
-
-		if state == versionAvailable {
-			nodeStatus.AvailableAt = time.Now().UTC().Truncate(time.Second)
-		}
-
-		st.Nodes[hostname] = nodeStatus
-	} else {
-		nodeStatus := st.Nodes[hostname]
-		nodeStatus.State = state
-		if state == versionAvailable {
-			nodeStatus.AvailableAt = time.Now().UTC().Truncate(time.Second)
-		}
-
-		st.Nodes[hostname] = nodeStatus
-	}
-
-	db.versionStatus[version.name] = st
-
 	current := db.mux.getCurrent()
 	db.mux.release(current)
-	for name := range db.versionStatus {
-		st := db.versionStatus[name].Nodes[hostname]
+	for name := range status.Versions {
+		st := status.Versions[name].Nodes[hostname]
 		st.Current = (current != nil && name == current.name)
 
-		db.versionStatus[name].Nodes[hostname] = st
+		status.Versions[name].Nodes[hostname] = st
 	}
+
+	return status
 }
 
-func (db *db) untrackVersion(version *version) {
-	db.versionStatusLock.Lock()
-	defer db.versionStatusLock.Unlock()
+func (vs *version) status() versionStatus {
+	vs.stateLock.Lock()
+	defer vs.stateLock.Unlock()
 
-	delete(db.versionStatus, version.name)
+	st := versionStatus{
+		Path:          vs.sequins.backend.DisplayPath(vs.db, vs.name),
+		NumPartitions: vs.numPartitions,
+		Nodes:         make(map[string]nodeVersionStatus),
+	}
+
+	partitions := make([]int, 0, len(vs.selectedLocalPartitions))
+	for p := range vs.selectedLocalPartitions {
+		partitions = append(partitions, p)
+	}
+
+	sort.Ints(partitions)
+	nodeStatus := nodeVersionStatus{
+		CreatedAt:  vs.created.UTC().Truncate(time.Second),
+		State:      vs.state,
+		Partitions: partitions,
+	}
+
+	if !vs.available.IsZero() {
+		nodeStatus.AvailableAt = vs.available.UTC().Truncate(time.Second)
+	}
+
+	hostname := "localhost"
+	if vs.sequins.peers != nil {
+		hostname = vs.sequins.peers.address
+	}
+
+	st.Nodes[hostname] = nodeStatus
+	return st
+}
+
+func (vs *version) setState(state versionState) {
+	vs.stateLock.Lock()
+	defer vs.stateLock.Unlock()
+
+	vs.state = state
+	if state == versionAvailable {
+		vs.available = time.Now()
+	}
 }

--- a/version.go
+++ b/version.go
@@ -107,7 +107,7 @@ func (vs *version) advertiseAndWait() bool {
 
 // hasPartition returns true if we have the partition available locally.
 func (vs *version) hasPartition(partition int) bool {
-	return vs.getBlockStore() != nil && (vs.partitions == nil || vs.partitions.local[partition])
+	return vs.getBlockStore() != nil && (vs.selectedLocalPartitions == nil || vs.selectedLocalPartitions[partition])
 }
 
 func (vs *version) close() {

--- a/version.go
+++ b/version.go
@@ -27,12 +27,16 @@ type version struct {
 	path                    string
 	db                      string
 	name                    string
-	created                 time.Time
 	blockStore              *blocks.BlockStore
 	blockStoreLock          sync.RWMutex
 	partitions              *partitions
 	numPartitions           int
 	selectedLocalPartitions map[int]bool
+
+	state     versionState
+	created   time.Time
+	available time.Time
+	stateLock sync.RWMutex
 }
 
 func newVersion(sequins *sequins, path, db, name string, numPartitions int) *version {
@@ -41,8 +45,10 @@ func newVersion(sequins *sequins, path, db, name string, numPartitions int) *ver
 		path:          path,
 		db:            db,
 		name:          name,
-		created:       time.Now(),
 		numPartitions: numPartitions,
+
+		created: time.Now(),
+		state:   versionBuilding,
 	}
 
 	var local map[int]bool

--- a/version.go
+++ b/version.go
@@ -117,11 +117,14 @@ func (vs *version) initBlockStore(path string) error {
 func (vs *version) close() {
 	close(vs.cancel)
 
-	vs.buildLock.Lock()
-	defer vs.buildLock.Unlock()
+	// This happens once the building goroutine gets the cancel and exits.
+	go func() {
+		vs.buildLock.Lock()
+		defer vs.buildLock.Unlock()
 
-	vs.partitions.close()
-	vs.blockStore.Close()
+		vs.partitions.close()
+		vs.blockStore.Close()
+	}()
 }
 
 func (vs *version) delete() error {


### PR DESCRIPTION
In service of trying to fix a few lurking bugs in the upgrade flows, I ended up stepping back and doing a somewhat more comprehensive refactor of the surrounding code. This PR altogether is pretty invasive, but each commit stands individually as a smaller refactor, so it hopefully shouldn't be too bad to review. We also fortunately have [pretty good functional tests](https://github.com/stripe/sequins/blob/master/cluster_test.go) for this stuff.

The fixes contained within, in ascending order of importance:
- The status webpage sometimes leaked versions, showing them as errored even after they'd been cleared.
- During startup, builds weren't respecting max_parallel_loads, which meant we could thrash the disk if a node joined a full cluster with nothing cached locally.
- Versions that were still building, but complete on peers, weren't switched to until they finished building. That's now decoupled; when a version is ready to serve, it's switched to.

r? @kitchen
As I mentioned above, this should be reviewed commit-by-commit.
