### PR TITLE
Make port consistent throughout "Getting Started"

### DIFF
--- a/doc/manual/README.md
+++ b/doc/manual/README.md
@@ -47,7 +47,7 @@ sequins a local path:
 Now you can query it (I'm using [httpie][httpie] here, but
 curl works just as well):
 
-    $ http localhost:9590/foo/bar
+    $ http localhost:9599/foo/bar
     HTTP/1.1 404 Not Found
     Content-Length: 0
     Content-Type: text/plain; charset=utf-8


### PR DESCRIPTION
An example uses port `9590` when Sequins was started up on port `9599` in an earlier example.

r? @colin-stripe 