### PR TITLE
Bump golang version to 1.7.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os:
   - linux
   - osx
 language: go
-go: 1.7
+go: 1.7.5
 sudo: false
 before_install:
 - export ZOOKEEPER_HOME="$HOME/zookeeper-3.4.8"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7
+FROM golang:1.7.5
 
 RUN apt-get update
 RUN apt-get install -y build-essential autoconf libtool pkg-config


### PR DESCRIPTION
We have been seeing many dns failures that look a lot like this bug:
https://github.com/golang/go/issues/16865

Sequins was running on the release version of go 1.7, this PR bumps it to the most recent stable version of go 1.7.5

r? @evan-stripe 