### PR TITLE
Store IP of sequins peers addresses in ZK.

### DIFF
--- a/sequins.go
+++ b/sequins.go
@@ -133,14 +133,12 @@ func (s *sequins) initCluster() error {
 		return err
 	}
 
-	ip := ""
+	ip := hostname
 	ipAddresses, err := net.LookupHost(hostname)
 	if err != nil {
 		return err
 	}
-	if len(ipAddresses) != 1 {
-		ip = hostname
-	} else {
+	if len(ipAddresses) == 1 {
 		ip = ipAddresses[0]
 	}
 

--- a/sequins.go
+++ b/sequins.go
@@ -132,24 +132,24 @@ func (s *sequins) initCluster() error {
 	if err != nil {
 		return err
 	}
-	ipAddresses, err := net.LookupHost(hostname)
+	
 	ip := ""
+	ipAddresses, err := net.LookupHost(hostname)
 	if err	!= nil {
 		return err
 	}
-	if len(ipAddresses) < 1 {
+	if len(ipAddresses) != 1 {
 		ip = hostname
 	} else {
 		ip = ipAddresses[0]
 	}
+
 	routableIpAddress := net.JoinHostPort(ip, port)
 	routableAddress := net.JoinHostPort(hostname, port)
 	shardID := s.config.Sharding.ShardID
 	if shardID == "" {
 		shardID = routableAddress
 	}
-
-
 
 	peers := sharding.WatchPeers(zkWatcher, shardID, routableIpAddress)
 	peers.WaitToConverge(s.config.Sharding.TimeToConverge.Duration)

--- a/sequins.go
+++ b/sequins.go
@@ -132,10 +132,10 @@ func (s *sequins) initCluster() error {
 	if err != nil {
 		return err
 	}
-	
+
 	ip := ""
 	ipAddresses, err := net.LookupHost(hostname)
-	if err	!= nil {
+	if err != nil {
 		return err
 	}
 	if len(ipAddresses) != 1 {

--- a/sequins.go
+++ b/sequins.go
@@ -132,14 +132,26 @@ func (s *sequins) initCluster() error {
 	if err != nil {
 		return err
 	}
-
+	ipAddresses, err := net.LookupHost(hostname)
+	ip := ""
+	if err	!= nil {
+		return err
+	}
+	if len(ipAddresses) < 1 {
+		ip = hostname
+	} else {
+		ip = ipAddresses[0]
+	}
+	routableIpAddress := net.JoinHostPort(ip, port)
 	routableAddress := net.JoinHostPort(hostname, port)
 	shardID := s.config.Sharding.ShardID
 	if shardID == "" {
 		shardID = routableAddress
 	}
 
-	peers := sharding.WatchPeers(zkWatcher, shardID, routableAddress)
+
+
+	peers := sharding.WatchPeers(zkWatcher, shardID, routableIpAddress)
 	peers.WaitToConverge(s.config.Sharding.TimeToConverge.Duration)
 
 	s.address = routableAddress


### PR DESCRIPTION
When sequins proxies requests to other nodes in the cluster, it round trips to dns.  We have seen some issues with dns lookup failures when the cluster is really busy.  This will just store the peer IP addresses in ZK, which should reduce the DNS load. 

The downside is sequins _can_ lose peers, if ip addresses change it would require sequins to be restarted. 

r? @evan-stripe 
cc @bartle-stripe  @jdelaney-stripe @cff-stripe @sankari-stripe @as3richa-stripe @jbancroft-stripe @dusty-stripe @jbancroft-stripe 