### PR TITLE
Filter out DBs and versions with invalid characters

### DIFF
--- a/doc/manual/1-1-basic-concepts/README.md
+++ b/doc/manual/1-1-basic-concepts/README.md
@@ -63,10 +63,12 @@ Instead, databases are versioned. To update a database, you present it with an
 entirely new copy of the dataset, called a **version**, by dropping it into the
 database folder in the source root.
 
-Database and version names are just arbitrary strings, and are compared
-lexicographically - so to update a database, you need to give it a version that
-is lexicographically greater than the current one. At Stripe we use `date
-+%Y%m%d` (eg `20160901`) and timestamps.
+Database and version names must consist of alphanumeric characters,
+hyphens, and underscores (path components are ignored if they include
+other characters). But otherwise, they are just arbitrary strings, and
+are compared lexicographically - so to update a database, you need to
+give it a version that is lexicographically greater than the current
+one. At Stripe we use `date +%Y%m%d` (eg `20160901`) and timestamps.
 
 Sequins will load this in the background and hotswap it in atomically.
 Additionally, Sequins returns an `X-Sequins-Version` header [on

--- a/sequins.go
+++ b/sequins.go
@@ -216,11 +216,19 @@ func (s *sequins) shutdown() {
 	s.storeLock.Unlock()
 }
 
+func (s *sequins) listDBs() ([]string, error) {
+	dbs, err := s.backend.ListDBs()
+	if err != nil {
+		return nil, err
+	}
+	return filterPaths(dbs), nil
+}
+
 func (s *sequins) refreshAll() {
 	s.refreshLock.Lock()
 	defer s.refreshLock.Unlock()
 
-	dbs, err := s.backend.ListDBs()
+	dbs, err := s.listDBs()
 	if err != nil {
 		log.Printf("Error listing DBs from %s: %s", s.backend.DisplayPath(""), err)
 		return

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"regexp"
+)
+
+var validPathRegexp = regexp.MustCompile("^[-_a-zA-Z0-9]+$")
+
+// Given a list of potential path components, filter out any that
+// contain invalid characters.
+//
+// Sequins only supports datasets that are alphanumeric + hyphen +
+// underscore.
+func filterPaths(paths []string) []string {
+	filtered := make([]string, 0, len(paths))
+
+	for _, p := range paths {
+		if validPathRegexp.MatchString(p) {
+			filtered = append(filtered, p)
+		}
+
+	}
+
+	return filtered
+}


### PR DESCRIPTION
We've seen problems from versions that inadvertently included special
characters (like '{'). To avoid problems, skip over anything that's
not alphanumeric.

r? @scottjab 
cc @stripe/storage 