### PR TITLE
add retries to s3backend::Open function

### DIFF
--- a/config.go
+++ b/config.go
@@ -96,7 +96,7 @@ func defaultConfig() sequinsConfig {
 		S3: s3Config{
 			Region:          "",
 			AccessKeyId:     "",
-			MaxRetries:      2,
+			MaxRetries:      3,
 			SecretAccessKey: "",
 		},
 		Sharding: shardingConfig{

--- a/config.go
+++ b/config.go
@@ -44,6 +44,7 @@ type storageConfig struct {
 type s3Config struct {
 	Region          string `toml:"region"`
 	AccessKeyId     string `toml:"access_key_id"`
+	MaxRetries      int    `toml:"max_retries"`
 	SecretAccessKey string `toml:"secret_access_key"`
 }
 
@@ -95,6 +96,7 @@ func defaultConfig() sequinsConfig {
 		S3: s3Config{
 			Region:          "",
 			AccessKeyId:     "",
+			MaxRetries:      2,
 			SecretAccessKey: "",
 		},
 		Sharding: shardingConfig{

--- a/main.go
+++ b/main.go
@@ -153,7 +153,7 @@ func s3Setup(bucketName string, path string, config sequinsConfig) *sequins {
 		Credentials: creds,
 	})
 
-	backend := backend.NewS3Backend(bucketName, path, s3.New(sess))
+	backend := backend.NewS3Backend(bucketName, path, config.S3.MaxRetries, s3.New(sess))
 	return newSequins(backend, config)
 }
 


### PR DESCRIPTION
Add retry functionality to the `Open` function for the s3 backend so that when calls to `GetObject` fail due to latency in updating the keys, it will be automatically handled.

r? @scottjab-stripe 
cc? @wei-stripe @jbancroft-stripe @dusty-stripe @bartle-stripe @ikdc-stripe