### PR TITLE
add retries to s3backend::Open function

### DIFF
--- a/backend/s3_backend.go
+++ b/backend/s3_backend.go
@@ -6,22 +6,27 @@ import (
 	"path"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 )
 
 type S3Backend struct {
-	bucket string
-	path   string
-	svc    *s3.S3
+	bucket     string
+	path       string
+	maxRetries int
+	svc        s3iface.S3API
 }
 
-func NewS3Backend(bucket string, s3path string, svc *s3.S3) *S3Backend {
+func NewS3Backend(bucket string, s3path string, maxRetries int, svc s3iface.S3API) *S3Backend {
 	return &S3Backend{
-		bucket: bucket,
-		path:   strings.TrimPrefix(path.Clean(s3path), "/"),
-		svc:    svc,
+		bucket:     bucket,
+		path:       strings.TrimPrefix(path.Clean(s3path), "/"),
+		maxRetries: maxRetries,
+		svc:        svc,
 	}
 }
 
@@ -160,6 +165,21 @@ func (s *S3Backend) Open(db, version, file string) (io.ReadCloser, error) {
 		Key:    aws.String(src),
 	}
 	resp, err := s.svc.GetObject(params)
+
+	// If the download failed, due to the key not being found, retry
+	// maxRetries number of times with an exponential backoff as it may
+	// have been due to latency.
+	backoff := time.Duration(1)
+	for i := 0; i < s.maxRetries && err != nil; i++ {
+		aerr, ok := err.(awserr.Error)
+		if ok && aerr.Code() == s3.ErrCodeNoSuchKey {
+			time.Sleep(backoff * time.Second)
+			resp, err = s.svc.GetObject(params)
+			backoff *= 2
+		} else {
+			break
+		}
+	}
 
 	if err != nil {
 		return nil, fmt.Errorf("error opening S3 path %s: %s", s.path, err)

--- a/config.go
+++ b/config.go
@@ -44,6 +44,7 @@ type storageConfig struct {
 type s3Config struct {
 	Region          string `toml:"region"`
 	AccessKeyId     string `toml:"access_key_id"`
+	MaxRetries      int    `toml:"max_retries"`
 	SecretAccessKey string `toml:"secret_access_key"`
 }
 
@@ -95,6 +96,7 @@ func defaultConfig() sequinsConfig {
 		S3: s3Config{
 			Region:          "",
 			AccessKeyId:     "",
+			MaxRetries:      3,
 			SecretAccessKey: "",
 		},
 		Sharding: shardingConfig{

--- a/main.go
+++ b/main.go
@@ -153,7 +153,7 @@ func s3Setup(bucketName string, path string, config sequinsConfig) *sequins {
 		Credentials: creds,
 	})
 
-	backend := backend.NewS3Backend(bucketName, path, s3.New(sess))
+	backend := backend.NewS3Backend(bucketName, path, config.S3.MaxRetries, s3.New(sess))
 	return newSequins(backend, config)
 }
 

--- a/s3_sequins_test.go
+++ b/s3_sequins_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -11,15 +11,35 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stripe/sequins/backend"
 )
 
-func setupS3(t *testing.T) *backend.S3Backend {
+type S3ClientMock struct {
+	s3iface.S3API
+	toggle             bool
+	returnGenericError bool
+}
 
+func (c *S3ClientMock) GetObject(*s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	c.toggle = !c.toggle
+
+	if c.toggle {
+		if c.returnGenericError {
+			return nil, errors.New("this is a mocked generic error")
+		}
+		return nil, awserr.New(s3.ErrCodeNoSuchKey, "this is a mocked NoSuchKey error", nil)
+	}
+
+	return &s3.GetObjectOutput{}, nil
+}
+
+func setupS3(t *testing.T) *backend.S3Backend {
 	bucket := os.Getenv("SEQUINS_TEST_BUCKET")
 	if bucket == "" {
 		t.Skip("Skipping s3 tests because SEQUINS_TEST_BUCKET isn't set")
@@ -27,7 +47,7 @@ func setupS3(t *testing.T) *backend.S3Backend {
 
 	sess := session.New(nil)
 	svc := s3.New(sess)
-	testBackend := backend.NewS3Backend(bucket, "test", svc)
+	testBackend := backend.NewS3Backend(bucket, "test", 3, svc)
 
 	// Remove old files from previous tests
 	err := delS3Prefix(svc, bucket, "test/")
@@ -42,8 +62,10 @@ func setupS3(t *testing.T) *backend.S3Backend {
 		require.NoError(t, err, "setup: putting %s", path.Join(sourceDest, "1", info.Name()))
 	}
 
-	putS3Blob(svc, bucket, "test/baby-names/0/_SUCCESS", nil)
-	putS3Blob(svc, bucket, "test/baby-names/foo", bytes.NewReader([]byte("rando file")))
+	err = putS3Blob(svc, bucket, "test/baby-names/0/_SUCCESS", nil)
+	require.NoError(t, err, "setup: putting _SUCCESS file")
+	err = putS3Blob(svc, bucket, "test/baby-names/foo", nil)
+	require.NoError(t, err, "setup: putting random file")
 
 	return testBackend
 }
@@ -73,6 +95,20 @@ func TestS3Backend(t *testing.T) {
 	files, err := s.ListFiles("baby-names", "0")
 	require.NoError(t, err, "it should be able to list files")
 	assert.Equal(t, 5, len(files), "the list of files should be correct")
+}
+
+func TestS3Retries(t *testing.T) {
+	retryBackend := backend.NewS3Backend("", "test", 1, &S3ClientMock{})
+	_, err := retryBackend.Open("", "", "")
+	require.NoError(t, err, "backend should retry and succeed the second time")
+
+	retryBackend = backend.NewS3Backend("", "test", 1, &S3ClientMock{returnGenericError: true})
+	_, err = retryBackend.Open("", "", "")
+	require.Error(t, err, "backend should not retry for errors other than s3.ErrCodeNoSuchKey")
+
+	noRetryBackend := backend.NewS3Backend("", "test", 0, &S3ClientMock{})
+	_, err = noRetryBackend.Open("", "", "")
+	require.Error(t, err, "backend should return an error on the first attempt and not retry")
 }
 
 func putS3(svc *s3.S3, bucket, dst, src string) error {


### PR DESCRIPTION
Add retry functionality to the `Open` function for the s3 backend so that when calls to `GetObject` fail due to latency in updating the keys, it will be automatically handled.

r? @scottjab-stripe 
cc? @stripe/storage