### PR TITLE
Run `go vet` as part of CI, and fix all violations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 - sh vendor/github.com/colinmarc/hdfs/setup_test_env.sh
 before_script:
 - make
-script: make test
+script: make test vet
 before_deploy: make release
 cache:
   directories:

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,9 @@ test: $(TEST_SOURCES)
 	# as well (sync.Pool doesn't ever share objects under -race).
 	$(CGO_PREAMBLE) go test -timeout 30s ./blocks -run TestBlockParallelReads
 
+vet:
+	$(CGO_PREAMBLE) go vet $(shell go list ./... | grep -v vendor)
+
 test_functional: sequins $(TEST_SOURCES)
 	$(CGO_PREAMBLE) go test -timeout 10m -run "^TestCluster"
 

--- a/db.go
+++ b/db.go
@@ -78,7 +78,7 @@ func (db *db) backfillVersions() error {
 
 		version, err := newVersion(db.sequins, db, db.localPath(v), v)
 		if err != nil {
-			log.Println("Error initializing version %s of %s: %s", db.name, v, err)
+			log.Printf("Error initializing version %s of %s: %s", db.name, v, err)
 			continue
 		}
 

--- a/jenkins_build.sh
+++ b/jenkins_build.sh
@@ -3,7 +3,7 @@
 set -eux
 
 cd /go/src/github.com/stripe/sequins
-make
+make sequins vet
 
 ./sequins --help 2>&1 | grep usage && echo 'binary looks good'
 

--- a/status.go
+++ b/status.go
@@ -35,7 +35,7 @@ type status struct {
 }
 
 type dbStatus struct {
-	Versions map[string]versionStatus `json:"versions",omitempty`
+	Versions map[string]versionStatus `json:"versions,omitempty"`
 }
 
 type versionStatus struct {

--- a/zk/watcher.go
+++ b/zk/watcher.go
@@ -430,7 +430,7 @@ func (w *Watcher) Close() {
 
 // sendErr sends the error over the channel, or discards it if the error is full.
 func sendErr(errs chan error, err error, path string, server string) {
-	log.Println("Zookeeper error: err=%q, path=%q, server=%q", err, path, server)
+	log.Printf("Zookeeper error: err=%q, path=%q, server=%q", err, path, server)
 
 	select {
 	case errs <- err:


### PR DESCRIPTION
r? @scottjab 
cc @stripe/storage 