### PR TITLE
bump golang version to 1.8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os:
   - linux
   - osx
 language: go
-go: 1.7.5
+go: 1.8.3
 sudo: false
 before_install:
 - wget http://apache.claz.org/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.5
+FROM golang:1.8.3
 
 RUN apt-get update
 RUN apt-get install -y build-essential autoconf libtool pkg-config


### PR DESCRIPTION
**Summary**

Upgrade the golang version to the latest stable release (1.8.3)

**Revert Plan**

`s/1.8.3/1.7.5`

r? @bartle-stripe 
cc? @stripe/storage 