### PR TITLE
remove mac travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os:
   - linux
-  - osx
 language: go
 go: 1.7.5
 sudo: false


### PR DESCRIPTION
**Summary**

This removes Mac travis CI tests.

**Motivation**

They're a pain and often fail.

r? @scottjab-stripe
cc? @stripe/storage