### PR TITLE
tweak sequins tags

### DIFF
--- a/build.go
+++ b/build.go
@@ -83,7 +83,7 @@ func (vs *version) addFiles(partitions map[int]bool) error {
 	for i, file := range vs.files {
 		if vs.stats != nil {
 			remaining := float64(len(vs.files) - i - 1)
-			tags := []string{fmt.Sprintf("db:%s", vs.db.name)}
+			tags := []string{fmt.Sprintf("sequins_db:%s", vs.db.name)}
 			vs.stats.Gauge("s3.queue_depth", remaining, tags, 1)
 		}
 
@@ -107,7 +107,7 @@ func (vs *version) addFile(file string, partitions map[int]bool) error {
 		start := time.Now()
 		defer func() {
 			duration := time.Since(start)
-			tags := []string{fmt.Sprintf("db:%s", vs.db.name)}
+			tags := []string{fmt.Sprintf("sequins_db:%s", vs.db.name)}
 			vs.stats.Timing("s3.download_duration", duration, tags, 1)
 		}()
 	}

--- a/sequins.go
+++ b/sequins.go
@@ -65,6 +65,7 @@ func (s *sequins) init() error {
 			log.Fatalf("Error connecting to statsd: %s", err)
 		}
 		statsdClient.Namespace = "sequins."
+		statsdClient.Tags = append(statsdClient.Tags, fmt.Sprintf("cluster:%s", s.config.Sharding.ClusterName))
 		s.stats = statsdClient
 	}
 


### PR DESCRIPTION
Change the tags used for sequins reporting to datadog to be more consistent with what is currently in use.

r? @scottjab-stripe 