### PR TITLE
Establish a minimum replication level before switching to a new version

### DIFF
--- a/build.go
+++ b/build.go
@@ -134,6 +134,12 @@ func (vs *version) addFile(file string, partitions map[int]bool) error {
 		return fmt.Errorf("reading %s: %s", disp, err)
 	}
 
+	// Intentionally hang, for tests.
+	hang := &vs.sequins.config.Test.Hang
+	if hang.Version == vs.name && hang.File == file {
+		time.Sleep(time.Hour)
+	}
+
 	return nil
 }
 

--- a/doc/manual/1-4-running-a-distributed-cluster/README.md
+++ b/doc/manual/1-4-running-a-distributed-cluster/README.md
@@ -77,7 +77,30 @@ asynchronously. That means that if Zookeeper becomes unavailable,
 Crucially, however, Zookeeper going down should **never impact an existing
 cluster's ability to service requests**.
 
-### Version Consistency Around Upgrades
+### Version upgrades
+
+Sequins uses Zookeeper to check which nodes have which partitions. It will
+upgrade to a new version when that version is minimally replicated—when every
+partition is available somewhere in the cluster.
+
+Note that this occurs before the version is fully replicated, and
+possibly even before the local node has any partitions.
+
+#### Replication
+
+During the window between an upgrade and full replication, Sequins is
+more vulnerable to node failure. You can mitigate this vulnerability by
+setting `sharding.min_replication`, so that Sequins waits for a certain
+amount of redundancy before triggering the upgrade.
+
+However, a high `min_replication` will also make upgrades take longer.
+In particular, if `min_replication` is the same as `replication`, a
+successful upgrade requires every single node to be up and running.
+
+Recommended settings for a stable cluster are therefore
+1 < `min_replication` < `replication` <= count(`shard_id`).
+
+#### Version consistency
 
 Nodes in a sequins cluster will make a best-effort attempt to upgrade a given
 database at more or less the same time. It is, of course, physically impossible

--- a/doc/manual/x-1-configuration-reference/README.md
+++ b/doc/manual/x-1-configuration-reference/README.md
@@ -161,6 +161,19 @@ int  | 2
 
 This is the number of replicas responsible for each partition.
 
+### min_replication
+
+Type | Default
+:--: | -------
+int  | 1
+
+This is the minimum number of replicas required for sequins to switch to
+a new version. Set this to a higher value to ensure data redundancy before
+upgrading.
+
+You probably don't want this to be equal to `replication`,
+or sequins will never upgrade versions if any node at all is down.
+
 ### time_to_converge
 
 Type   | Default

--- a/sequins.conf.example
+++ b/sequins.conf.example
@@ -77,6 +77,13 @@ source = "hdfs://namenode:8020/path/to/sequins"
 # replication = 2
 # This is the number of replicas responsible for each partition.
 
+# min_replication = 1
+# This is the minimum number of replicas required for sequins to switch to
+# a new version. Set this to a higher value to ensure data redundancy before
+# upgrading.
+# You probably don't want this to be equal to `replication`,
+# or sequins will never upgrade versions if any node at all is down.
+
 # time_to_converge = "10s"
 # Upon startup, sequins will wait this long for the set of known peers to
 # stabilize.

--- a/version.go
+++ b/version.go
@@ -69,8 +69,13 @@ func newVersion(sequins *sequins, db *db, path, name string) (*version, error) {
 		stats: sequins.stats,
 	}
 
+	minReplication := 1
+	if sequins.config.Sharding.Enabled {
+		minReplication = sequins.config.Sharding.MinReplication
+	}
+
 	vs.partitions = sharding.WatchPartitions(sequins.zkWatcher, sequins.peers,
-		db.name, name, len(files), sequins.config.Sharding.Replication)
+		db.name, name, len(files), sequins.config.Sharding.Replication, minReplication)
 
 	err = vs.initBlockStore(path)
 	if err != nil {


### PR DESCRIPTION
This prevents errors in the following case:

* A new version becomes available
* Nodes start reading the files from the new version, but some nodes are faster than others
* At some point, at least one replica of each partition exists, and the new version goes active
    * Because of variable speed, many partitions still have only one replica
* A node goes down, and parts of the new version are unavailable. Clients get errors
* Eventually other nodes read enough data, and things settle down

I think my changes are roughly correct, however this is really hard to test. I have a partial test case, but I had to add some grotty code to simulate crashes, and I'm still getting sporadic failures.

r? @bartle-stripe 