### PR TITLE
Canonicalize import sorting with gogroup

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/samuel/go-zookeeper/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/stripe/sequins/zk/zktest"
 )
 

--- a/hdfs_sequins_test.go
+++ b/hdfs_sequins_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/colinmarc/hdfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/stripe/sequins/backend"
 )
 

--- a/main.go
+++ b/main.go
@@ -13,8 +13,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/colinmarc/hdfs"
-	"github.com/stripe/sequins/backend"
 	"gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/stripe/sequins/backend"
 )
 
 var (

--- a/s3_sequins_test.go
+++ b/s3_sequins_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/stripe/sequins/backend"
 )
 

--- a/zk/watcher_test.go
+++ b/zk/watcher_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/samuel/go-zookeeper/zk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/stripe/sequins/zk/zktest"
 )
 


### PR DESCRIPTION
The order of imports in almost everything in sequins is: core, other, sequins. Use gogroup to fix violators.

r? @scottjab 