### PR TITLE
Double Sequins' timeout for ZK sessions and Ignore ErrNodeExists 

### DIFF
--- a/zk/watcher.go
+++ b/zk/watcher.go
@@ -331,9 +331,7 @@ func (w *Watcher) watchChildren(node string, wn watchedNode) error {
 			case reconnecting = <-wn.cancel:
 				return
 			case ev := <-events:
-
 				if ev.Err != nil {
-					log.Println("DEBUG: callsite=watcher.WatchChildren")
 					sendErr(w.errs, ev.Err, ev.Path, ev.Server)
 					<-wn.cancel
 					return

--- a/zk/watcher.go
+++ b/zk/watcher.go
@@ -238,7 +238,7 @@ func (w *Watcher) createEphemeral(node string) error {
 		_, err := w.conn.Create(node, []byte{}, zk.FlagEphemeral, defaultZkACL)
 		if err == nil {
 			break
-		} else if err != nil && err != zk.ErrNoNode {
+		} else if err != nil && err != zk.ErrNoNode && err != zk.ErrNodeExists {
 			return err
 		}
 

--- a/zk/watcher.go
+++ b/zk/watcher.go
@@ -333,6 +333,7 @@ func (w *Watcher) watchChildren(node string, wn watchedNode) error {
 			case ev := <-events:
 
 				if ev.Err != nil {
+					log.Println("DEBUG: callsite=watcher.WatchChildren")
 					sendErr(w.errs, ev.Err, ev.Path, ev.Server)
 					<-wn.cancel
 					return

--- a/zk/watcher.go
+++ b/zk/watcher.go
@@ -180,7 +180,8 @@ Reconnect:
 	for {
 		if !first {
 			// Wait before trying to reconnect again.
-			wait := time.NewTimer(w.sessionTimeout)
+			// Let's wait longer than the ZK client.
+			wait := time.NewTimer(w.sessionTimeout * 2)
 			select {
 			case <-w.shutdown:
 				break Reconnect
@@ -188,7 +189,7 @@ Reconnect:
 			}
 
 			err := w.reconnect()
-			if err != nil {
+			if err != nil && w.conn.State() == zk.StateDisconnected {
 				log.Println("Error reconnecting to zookeeper:", err)
 				continue Reconnect
 			}


### PR DESCRIPTION
This PR addresses two issues:

1. Sequins is racing the ZK server's timeouts, Sequins will timeout the goroutine before ZK times itself out.  ZK then will still be timing out when Sequins reconnects.  This doubling the timeout on the goroutine will let ZK handle the timeout of its sockets and znodes.  We should still see the timeout happen though a disconnection if this happens.  The timeout on the goroutine is mostly for thread lock safety. 

2. When sequins creates parent znodes sometimes it will fail if the parents are already created, this leads to a reconnect.  We should ignore znode exists errors when we are creating the parents.

r?  @jerry-stripe 
cc @stripe/storage 
