### PR TITLE
Use smallest missing shardID if none is given

### DIFF
--- a/sequins.go
+++ b/sequins.go
@@ -135,9 +135,9 @@ func (s *sequins) joinCluster(zkWatcher *zk.Watcher, routableIpAddress string) (
 				peersNotJoined := sharding.WatchPeersNoJoin(zkWatcher)
 				peersNotJoined.WaitToConverge(s.config.Sharding.TimeToConverge.Duration)
 
-				shardID, err = peersNotJoined.SmallestMin()
+				shardID, err = peersNotJoined.SmallestAvailableShardID()
 				if err != nil {
-					return nil, fmt.Errorf("Error running SmallestMin: %q", err)
+					return nil, fmt.Errorf("Error running SmallestAvailableShardID: %q", err)
 				}
 				log.Printf("Identified %q as smallest missing shardID", shardID)
 

--- a/sharding/peers.go
+++ b/sharding/peers.go
@@ -36,6 +36,10 @@ type peer struct {
 }
 
 func (p *Peers) SmallestMin() (string, error) {
+	if len(p.peers) == 0 {
+		return "1", nil
+	}
+
 	peerList := make([]int, len(p.peers), len(p.peers))
 	i := 0
 	for peer := range p.peers {

--- a/sharding/peers.go
+++ b/sharding/peers.go
@@ -36,10 +36,6 @@ type peer struct {
 }
 
 func (p *Peers) SmallestAvailableShardID() (string, error) {
-	if len(p.peers) == 0 {
-		return "1", nil
-	}
-
 	peerList := make([]int, len(p.peers), len(p.peers))
 	i := 0
 	for peer := range p.peers {
@@ -53,10 +49,6 @@ func (p *Peers) SmallestAvailableShardID() (string, error) {
 	}
 
 	sort.Ints(peerList)
-
-	if peerList[0] != 1 {
-		return "1", nil
-	}
 
 	prevNum := 0
 	for _, num := range peerList {

--- a/sharding/peers.go
+++ b/sharding/peers.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"path"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -31,6 +33,50 @@ type Peers struct {
 type peer struct {
 	shardID string
 	address string
+}
+
+func (p *Peers) SmallestMin() (string, error) {
+	peerList := make([]int, len(p.peers), len(p.peers))
+	i := 0
+	for peer := range p.peers {
+		num, err := strconv.Atoi(peer.shardID)
+		if err != nil {
+			return "", fmt.Errorf("Can't convert shardID %q to int", peer.shardID)
+		}
+
+		peerList[i] = num
+		i++
+	}
+
+	sort.Ints(peerList)
+
+	if peerList[0] != 1 {
+		return "1", nil
+	}
+
+	prevNum := 0
+	for _, num := range peerList {
+		if num != prevNum+1 {
+			return fmt.Sprint(prevNum + 1), nil
+		}
+
+		prevNum = num
+	}
+
+	return fmt.Sprint(prevNum + 1), nil
+}
+
+func WatchPeersNoJoin(zkWatcher *zk.Watcher) *Peers {
+	p := &Peers{
+		peers: make(map[peer]bool),
+		ring:  consistent.New(),
+		resetConvergenceTimer: make(chan bool),
+	}
+
+	updates, disconnected := zkWatcher.WatchChildren("nodes")
+	go p.sync(updates, disconnected)
+
+	return p
 }
 
 func WatchPeers(zkWatcher *zk.Watcher, shardID, address string) *Peers {

--- a/sharding/peers.go
+++ b/sharding/peers.go
@@ -35,7 +35,7 @@ type peer struct {
 	address string
 }
 
-func (p *Peers) SmallestMin() (string, error) {
+func (p *Peers) SmallestAvailableShardID() (string, error) {
 	if len(p.peers) == 0 {
 		return "1", nil
 	}

--- a/sharding/peers_test.go
+++ b/sharding/peers_test.go
@@ -1,0 +1,70 @@
+package sharding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPeers_SmallestMin(t *testing.T) {
+	t.Parallel()
+
+	peers := &Peers{
+		peers: map[peer]bool{
+			peer{
+				shardID: "2",
+			}: true,
+			peer{
+				shardID: "4",
+			}: true,
+		},
+	}
+	result, err := peers.SmallestMin()
+	assert.NoError(t, err)
+	assert.Equal(t, "1", result)
+
+	peers = &Peers{
+		peers: map[peer]bool{
+			peer{
+				shardID: "1",
+			}: true,
+			peer{
+				shardID: "3",
+			}: true,
+		},
+	}
+	result, err = peers.SmallestMin()
+	assert.NoError(t, err)
+	assert.Equal(t, "2", result)
+
+	peers = &Peers{
+		peers: map[peer]bool{
+			peer{
+				shardID: "1",
+			}: true,
+			peer{
+				shardID: "2",
+			}: true,
+		},
+	}
+	result, err = peers.SmallestMin()
+	assert.NoError(t, err)
+	assert.Equal(t, "3", result)
+
+	peers = &Peers{
+		peers: map[peer]bool{
+			peer{
+				shardID: "1",
+			}: true,
+			peer{
+				shardID: "4",
+			}: true,
+			peer{
+				shardID: "5",
+			}: true,
+		},
+	}
+	result, err = peers.SmallestMin()
+	assert.NoError(t, err)
+	assert.Equal(t, "2", result)
+}

--- a/sharding/peers_test.go
+++ b/sharding/peers_test.go
@@ -67,4 +67,11 @@ func TestSmallestAvailableShardID(t *testing.T) {
 	result, err = peers.SmallestAvailableShardID()
 	assert.NoError(t, err)
 	assert.Equal(t, "2", result)
+
+	peers = &Peers{
+		peers: map[peer]bool{},
+	}
+	result, err = peers.SmallestAvailableShardID()
+	assert.NoError(t, err)
+	assert.Equal(t, "1", result)
 }

--- a/sharding/peers_test.go
+++ b/sharding/peers_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPeers_SmallestMin(t *testing.T) {
+func TestSmallestAvailableShardID(t *testing.T) {
 	t.Parallel()
 
 	peers := &Peers{
@@ -19,7 +19,7 @@ func TestPeers_SmallestMin(t *testing.T) {
 			}: true,
 		},
 	}
-	result, err := peers.SmallestMin()
+	result, err := peers.SmallestAvailableShardID()
 	assert.NoError(t, err)
 	assert.Equal(t, "1", result)
 
@@ -33,7 +33,7 @@ func TestPeers_SmallestMin(t *testing.T) {
 			}: true,
 		},
 	}
-	result, err = peers.SmallestMin()
+	result, err = peers.SmallestAvailableShardID()
 	assert.NoError(t, err)
 	assert.Equal(t, "2", result)
 
@@ -47,7 +47,7 @@ func TestPeers_SmallestMin(t *testing.T) {
 			}: true,
 		},
 	}
-	result, err = peers.SmallestMin()
+	result, err = peers.SmallestAvailableShardID()
 	assert.NoError(t, err)
 	assert.Equal(t, "3", result)
 
@@ -64,7 +64,7 @@ func TestPeers_SmallestMin(t *testing.T) {
 			}: true,
 		},
 	}
-	result, err = peers.SmallestMin()
+	result, err = peers.SmallestAvailableShardID()
 	assert.NoError(t, err)
 	assert.Equal(t, "2", result)
 }

--- a/zk/watcher.go
+++ b/zk/watcher.go
@@ -216,9 +216,6 @@ func (w *Watcher) CreateIDAssignmentLock() *zk.Lock {
 	w.lock.RLock()
 	defer w.lock.RUnlock()
 
-	w.hooksLock.Lock()
-	defer w.hooksLock.Unlock()
-
 	return zk.NewLock(w.conn, node, zk.WorldACL(zk.PermAll))
 }
 

--- a/zk/watcher.go
+++ b/zk/watcher.go
@@ -210,6 +210,18 @@ Reconnect:
 	w.cancelWatches()
 }
 
+func (w *Watcher) CreateIDAssignmentLock() *zk.Lock {
+	node := path.Join(w.prefix, "id_assignment_lock")
+
+	w.lock.RLock()
+	defer w.lock.RUnlock()
+
+	w.hooksLock.Lock()
+	defer w.hooksLock.Unlock()
+
+	return zk.NewLock(w.conn, node, zk.WorldACL(zk.PermAll))
+}
+
 // CreateEphemeral creates an ephemeral node on the zookeeper cluster. Any
 // needed parent nodes are also created, as permanent nodes. The ephemeral is
 // then recreated any time the Watcher reconnects.


### PR DESCRIPTION
Tested with the following procedure:
1. Remove `shard_id` from the configuration file
2. Restart Sequins and make sure it does smallest missing to figure out the correct `shardID`
3. Restart Sequins again and make sure it reads from the `self_assigned_id` file
4. Change the `self_assigned_id` file to be "0\n" and then restore the configuration file to include `shard_id` again
5. Restart Sequins again and make sure it uses the configuration file over the `self_assigned_id` file

I tested this on tha node with the lowest shardID, the highest shardID, and a shardID in the middle.

This has a fair amount of logging lines. Are there any you think I should remove?

r? @scottjab-stripe 