### PR TITLE
Expose node's shardID in /healthcheck

### DIFF
--- a/sharding/peers.go
+++ b/sharding/peers.go
@@ -18,7 +18,7 @@ const peerSelf = "(self)"
 // Peers represents a remote list of peers, synced with zookeeper. It's also
 // responsible for advertising this particular node's existence.
 type Peers struct {
-	shardID string
+	ShardID string
 	address string
 
 	peers map[peer]bool
@@ -35,14 +35,14 @@ type peer struct {
 
 func WatchPeers(zkWatcher *zk.Watcher, shardID, address string) *Peers {
 	p := &Peers{
-		shardID: shardID,
+		ShardID: shardID,
 		address: address,
 		peers:   make(map[peer]bool),
 		ring:    consistent.New(),
 		resetConvergenceTimer: make(chan bool),
 	}
 
-	node := path.Join("nodes", fmt.Sprintf("%s@%s", p.shardID, p.address))
+	node := path.Join("nodes", fmt.Sprintf("%s@%s", p.ShardID, p.address))
 	zkWatcher.CreateEphemeral(node)
 
 	updates, disconnected := zkWatcher.WatchChildren("nodes")
@@ -108,7 +108,7 @@ func (p *Peers) updatePeers(addrs []string) {
 
 	log.Println("Peers: ", disp)
 
-	shards[p.shardID] = true
+	shards[p.ShardID] = true
 	allShards := make([]string, 0, len(shards))
 	for shard := range shards {
 		allShards = append(allShards, shard)
@@ -165,7 +165,7 @@ func (p *Peers) pick(partitionId string, n int) []string {
 		}
 	}
 
-	if shards[p.shardID] {
+	if shards[p.ShardID] {
 		addrs = append(addrs, peerSelf)
 	}
 

--- a/status.go
+++ b/status.go
@@ -77,6 +77,10 @@ func (s *sequins) serveHealth(w http.ResponseWriter, r *http.Request) {
 
 	s.dbsLock.RUnlock()
 
+	if s.config.Sharding.Enabled {
+		w.Header().Set("X-Sequins-Shard-ID", s.peers.ShardID)
+	}
+
 	allNodesAvailable := true
 	statuses := make(map[string]map[string]versionState)
 


### PR DESCRIPTION
This is useful information to expose to users. It's also needed so that we can write automated tests for auto-assigning shardIDs.

r? @scottjab-stripe 