### PR TITLE
Change port in guide from 9590 to 9599

### DIFF
--- a/doc/manual/1-5-healthchecks-and-monitoring/README.md
+++ b/doc/manual/1-5-healthchecks-and-monitoring/README.md
@@ -10,12 +10,12 @@ each database:
 
 The information presented represents the whole cluster in the distributed case,
 and should be the same no matter which node you ask. You can also ask for a
-specific db, by visiting `/<db>` (in this example: `localhost:9590/flights`).
+specific db, by visiting `/<db>` (in this example: `localhost:9599/flights`).
 
 Finally, you can get a JSON representation of the same information by fetching
 with `Accept: application/json`:
 
-    $ http localhost:9590 'Accept:application/json'
+    $ http localhost:9599 'Accept:application/json'
     {
         "dbs": {
             "flights": {


### PR DESCRIPTION
By default Sequins uses port 9599 and that's the port used in all examples in the guide so for user experience we should keep it consistent.

r? @jerry-stripe 