### PR TITLE
Refactor functional tests and have them run again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 - sh vendor/github.com/colinmarc/hdfs/setup_test_env.sh
 before_script:
 - make
-script: make test vet
+script: make test test_functional vet
 before_deploy: make release
 cache:
   directories:


### PR DESCRIPTION
### Summary

Functional tests were disabled in CI almost a year ago due to flakiness (62b72b01c27ccbd7e77202b240ac8b713bb2e4d9). This refactor reenables them and address the sources of flakiness:

* There was no checking to see if Sequins actually starts up when `start` is called. This makes it possible for Sequins to randomly choose a port that's in use, fail to start up, but have the tests continue (and then fail) [0]
* Sometimes Sequins would start up too quickly and the state polling would miss states like `down`. Because this PR changes it to better control the startup process we don't need to poll for the initial `down` state.
* The `testClient` timeout was pretty low and would sometimes cause issues.

### Testing Process

Testing this change has consisted of running the functional test suite 100 times locally and 60 times on Travis. None of these runs failed.

### Future Work

I think we can make the testing framework for functional tests even better. Right now they rely heavily on polling the current state of Sequins. This works pretty well, but is susceptible to timing issues (if Sequins is too fast the polling can miss a state). Instead we should do one of the following:
* Have Sequins output its state and then using the log as the source of progression.
* Assert the progression at certain times throughout the test where it's known to be stable.

### Footnotes

[0] This was actually a compounding issue. The test would fail with a `panic` so the `defer tc.tearDown()` functions would never be run, leaving a lot of Sequins nodes running in the background. This would increase the likelihood of reusing a port in future tests.

Thanks to @jeremy-stripe for help with figuring out what was causing issues in these tests.

r? @scottjab-stripe 
cc @vasi-stripe @bartle-stripe @jerry-stripe @dusty-stripe