### PR TITLE
Add max_retries to example configuration file

### DIFF
--- a/sequins.conf.example
+++ b/sequins.conf.example
@@ -67,6 +67,9 @@ source = "hdfs://namenode:8020/path/to/sequins"
 # variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY will be used, or IAM
 # instance role credentials if they are available.
 
+# max_retries = 3
+# Number of times to try an S3 download before returning an error.
+
 [sharding]
 
 # enabled = false


### PR DESCRIPTION
The example config file is missing a line for `s3.max_retries`

r? @scottjab-stripe 
cc @dusty-stripe @jerry-stripe @bartle-stripe 