### PR TITLE
have healthcheck endpoint return 200 iff the latest versions are heal…

### DIFF
--- a/status.go
+++ b/status.go
@@ -81,25 +81,35 @@ func (s *sequins) serveHealth(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Sequins-Shard-ID", s.peers.ShardID)
 	}
 
-	allNodesAvailable := true
-	statuses := make(map[string]map[string]versionState)
-
 	// Iterate through all of the nodes of the local databases and ensure
 	// that the versions they own are all marked as available. A single
 	// version being in an unvailable state results in an error response.
+	statuses := make(map[string]map[string]nodeVersionStatus)
 	for dbKey, dbValue := range status.DBs {
 		for versionKey, versionValue := range dbValue.Versions {
 			for _, nodeValue := range versionValue.Nodes {
-				_, ok := statuses[dbKey]
-				if !ok {
-					statuses[dbKey] = make(map[string]versionState)
+				if _, ok := statuses[dbKey]; !ok {
+					statuses[dbKey] = make(map[string]nodeVersionStatus)
 				}
-
-				statuses[dbKey][versionKey] = nodeValue.State
-				if nodeValue.State != versionAvailable {
-					allNodesAvailable = false
-				}
+				statuses[dbKey][versionKey] = nodeValue
 			}
+		}
+	}
+
+	// Iterate through all of the nodes and ensure that the latest version
+	// is available. Determine the latest version of a database by sorting
+	// them first.
+	latestVersionsAvailable := true
+	for _, versions := range statuses {
+		sortedVersions := make([]string, 0, len(versions))
+		for version := range versions {
+			sortedVersions = append(sortedVersions, version)
+		}
+		sort.Strings(sortedVersions)
+
+		if versions[sortedVersions[0]].State != versionAvailable {
+			latestVersionsAvailable = false
+			break
 		}
 	}
 
@@ -111,7 +121,7 @@ func (s *sequins) serveHealth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	if allNodesAvailable {
+	if latestVersionsAvailable {
 		w.WriteHeader(http.StatusOK)
 	} else {
 		w.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
**Summary**
This changes the healthcheck response such that 200 will only be returned if the _latest_ version of each db is available. Previously, it required that all versions of each db were available to return 200. This also includes more general information about the given node for each version as opposed to just the status.

**Motivation**
This makes it possible to simplify the `roll-sequins` golem as it will no longer have to duplicate this logic and instead just check for a 200 status code. Also prepares for status page changes by including partition/block information in the healthcheck.

**Test plan**
Automated tests

**Rollout/monitoring/revert plan**
Revert commit

r? @scottjab-stripe
cc? @stripe/storage