### PR TITLE
Use status 499 when client cancels request

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -27,6 +27,7 @@ type sequinsStats struct {
 		status200 int64
 		status400 int64
 		status404 int64
+		status499 int64
 		status500 int64
 		status501 int64
 		status502 int64
@@ -120,6 +121,7 @@ func (s *sequinsStats) updateRequestStats() {
 			s.Qps.status200 = 0
 			s.Qps.status400 = 0
 			s.Qps.status404 = 0
+			s.Qps.status499 = 0
 			s.Qps.status500 = 0
 			s.Qps.status501 = 0
 			s.Qps.status502 = 0
@@ -135,6 +137,8 @@ func (s *sequinsStats) updateRequestStats() {
 				s.Qps.status400++
 			case 404:
 				s.Qps.status404++
+			case 499:
+				s.Qps.status499++
 			case 500:
 				s.Qps.status500++
 			case 501:
@@ -159,6 +163,7 @@ func (s *sequinsStats) snapshotRequestStats() {
 	s.Qps.ByStatus["200"] = s.Qps.status200
 	s.Qps.ByStatus["400"] = s.Qps.status400
 	s.Qps.ByStatus["404"] = s.Qps.status404
+	s.Qps.ByStatus["499"] = s.Qps.status499
 	s.Qps.ByStatus["500"] = s.Qps.status500
 	s.Qps.ByStatus["501"] = s.Qps.status501
 	s.Qps.ByStatus["502"] = s.Qps.status502

--- a/serve.go
+++ b/serve.go
@@ -85,6 +85,11 @@ func (vs *version) serveProxied(w http.ResponseWriter, r *http.Request,
 		log.Printf("All peers timed out for /%s/%s (version %s)", vs.db.name, key, vs.name)
 		w.WriteHeader(http.StatusGatewayTimeout)
 		return
+	} else if err == errRequestCanceled {
+		// The connection was closed by the client. 499.
+		log.Printf("Connection closed by client for /%s/%s (version %s)", vs.db.name, key, vs.name)
+		w.WriteHeader(499)
+		return
 	} else if err != nil {
 		// Some other error. 500.
 		vs.serveError(w, key, err)
@@ -117,11 +122,7 @@ func (vs *version) serveNotFound(w http.ResponseWriter) {
 
 func (vs *version) serveError(w http.ResponseWriter, key string, err error) {
 	log.Printf("Error fetching value for /%s/%s: %s\n", vs.db.name, key, err)
-	if err == errRequestCanceled {
-		w.WriteHeader(499)
-	} else {
-		w.WriteHeader(http.StatusInternalServerError)
-	}
+	w.WriteHeader(http.StatusInternalServerError)
 }
 
 func shuffle(vs []string) []string {

--- a/serve.go
+++ b/serve.go
@@ -117,7 +117,11 @@ func (vs *version) serveNotFound(w http.ResponseWriter) {
 
 func (vs *version) serveError(w http.ResponseWriter, key string, err error) {
 	log.Printf("Error fetching value for /%s/%s: %s\n", vs.db.name, key, err)
-	w.WriteHeader(http.StatusInternalServerError)
+	if err == errRequestCanceled {
+		w.WriteHeader(499)
+	} else {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
 }
 
 func shuffle(vs []string) []string {


### PR DESCRIPTION
When the client cancels a request before it finishes we don't want to count that as an internal server error because it isn't. Instead we should use 499 to indicate that the client closed the request[0].

[0] Note that 499 is a nonstandard HTTP status code and not in the official spec.

r? @bartle-stripe 
cc @jerry-stripe @vasi-stripe @scottjab-stripe @dusty-stripe