### PR TITLE
initialize dbStatus with Version to prevent status page 502

### DIFF
--- a/status.go
+++ b/status.go
@@ -69,7 +69,7 @@ type status struct {
 }
 
 type dbStatus struct {
-	Versions map[string]versionStatus `json:"versions,omitempty"`
+	Versions map[string]versionStatus `json:"versions"`
 }
 
 type versionStatus struct {
@@ -283,7 +283,7 @@ func (s *sequins) getPeerStatus(peer string, db string) (status, error) {
 	if db == "" {
 		err = decoder.Decode(&status)
 	} else {
-		s := dbStatus{}
+		s := dbStatus{Versions: make(map[string]versionStatus)}
 		err = decoder.Decode(&s)
 		if err != nil {
 			return status, err


### PR DESCRIPTION
Fixes the case where the `Versions` map inside the `dbStatus` struct was referred to when uninitialized. Will provide code path through comments to be more clear about how this was happening. I'm not 100% confident that this was _the_ problem, but I think this is definitely a problem.

r? @scottjab-stripe 
cc? @stripe/storage 