### PR TITLE
Shard IDs: Don't wait for convergence too much

### DIFF
--- a/sequins.go
+++ b/sequins.go
@@ -28,6 +28,14 @@ import (
 
 const defaultMaxLoads = 10
 
+// While we wait to pick a shard ID, other nodes are prohibited from joining the cluster because
+// we're holding a lock. This timeout can therefore be pretty short.
+//
+// Indeed, it needs to be shorter than the regular cluster convergence timeout, or
+// the cluster will be seen to "converge" when it's really just waiting for someone to release
+// the lock.
+const shardIDConvergenceMax = 3 * time.Second
+
 var errDirLocked = errors.New("failed to acquire lock")
 
 type sequins struct {
@@ -122,10 +130,15 @@ func (s *sequins) init() error {
 	return nil
 }
 
-func (s *sequins) joinCluster(zkWatcher *zk.Watcher, routableIpAddress string) (*sharding.Peers, error) {
+func (s *sequins) ensureShardID(zkWatcher *zk.Watcher, routableIpAddress string) (*sharding.Peers, error) {
 	lock := zkWatcher.CreateIDAssignmentLock()
 	lock.Lock()
 	defer lock.Unlock()
+
+	convergenceTime := s.config.Sharding.TimeToConverge.Duration
+	if convergenceTime > shardIDConvergenceMax {
+		convergenceTime = shardIDConvergenceMax
+	}
 
 	shardID := s.config.Sharding.ShardID
 	if shardID == "" {
@@ -136,7 +149,7 @@ func (s *sequins) joinCluster(zkWatcher *zk.Watcher, routableIpAddress string) (
 				log.Print("No self-assigned ID file found")
 
 				peersNotJoined := sharding.WatchPeersNoJoin(zkWatcher)
-				peersNotJoined.WaitToConverge(s.config.Sharding.TimeToConverge.Duration)
+				peersNotJoined.WaitToConverge(convergenceTime)
 
 				shardID, err = peersNotJoined.SmallestAvailableShardID()
 				if err != nil {
@@ -152,7 +165,7 @@ func (s *sequins) joinCluster(zkWatcher *zk.Watcher, routableIpAddress string) (
 				return nil, fmt.Errorf("Could not check %q exists: %q", fp, err)
 			}
 		} else {
-			log.Print("Self-assigned ID file found. Attemtping to read.")
+			log.Print("Self-assigned ID file found. Attempting to read.")
 			bytes, err := ioutil.ReadFile(fp)
 			if err != nil {
 				return nil, fmt.Errorf("Could not read %q: %q", fp, err)
@@ -162,10 +175,17 @@ func (s *sequins) joinCluster(zkWatcher *zk.Watcher, routableIpAddress string) (
 		}
 	}
 	log.Printf("Using %q as shardID", shardID)
-
 	peers := sharding.WatchPeers(zkWatcher, shardID, routableIpAddress)
-	peers.WaitToConverge(s.config.Sharding.TimeToConverge.Duration)
+	return peers, nil
+}
 
+func (s *sequins) joinCluster(zkWatcher *zk.Watcher, routableIpAddress string) (*sharding.Peers, error) {
+	// The shard-ID lock is released inside here--we don't need that lock to be held while we wait to converge.
+	peers, err := s.ensureShardID(zkWatcher, routableIpAddress)
+	if err != nil {
+		return nil, err
+	}
+	peers.WaitToConverge(s.config.Sharding.TimeToConverge.Duration)
 	return peers, nil
 }
 


### PR DESCRIPTION
The current convergence pattern isn't great. We wait to converge *twice* while holding a lock. And the lock prevents other nodes from joining. This causes a new cluster to converge on too-small a state while most nodes are blocked. This made it hard to write tests.

We can take the second wait to converge out of the lock entirely. And the first one we can shorten, since while the lock is held we can be pretty sure nodes aren't joining.