### PR TITLE
replace hash ring partition assignment with sequential scheme

### DIFF
--- a/doc/manual/2-2-sharding/README.md
+++ b/doc/manual/2-2-sharding/README.md
@@ -92,14 +92,14 @@ backfills them. To do that, it
 
  1. Decides which partitions it is responsible for offline, by:
 
-    a. Putting all the nodes it knows about, including itself, on a partition
-       ring
+    a. Creating an array of all partitions in sorted order * the replication
+       factor. (e.g. [1, 1, 1, 2, 2, 2, ...])
 
-    b. For a given partition, placing that on the partition ring and picking the
-       two (or whatever the replication factor is) nodes closest to that point,
-       counter clockwise.
+    b. Creating an array of all nodes it knows about in sorted order based on
+       their shard id.
 
-    c. If it itself is one of those nodes, then it is responsible for that partition.
+    c. For all of the partitions at index `idx`, if `idx % len(nodes)` is equal
+       to its position in the node array, we assign it that partition.
 
  2. Starts loading and preparing those partitions. As they become available, it
     writes an ephemeral node to the partition map, at

--- a/sharding/peers.go
+++ b/sharding/peers.go
@@ -175,8 +175,8 @@ func (p *Peers) WaitToConverge(dur time.Duration) {
 	}
 }
 
-// Get returns the current list of peers.
-func (p *Peers) Get() []string {
+// GetAddresses returns the current list of peer addresses.
+func (p *Peers) GetAddresses() []string {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
@@ -186,6 +186,19 @@ func (p *Peers) Get() []string {
 	}
 
 	return addrs
+}
+
+// GetShardIds returns the current list of shard ids.
+func (p *Peers) GetShardIds() []string {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	ids := make([]string, 0, len(p.peers))
+	for peer := range p.peers {
+		ids = append(ids, peer.shardID)
+	}
+
+	return ids
 }
 
 // pick returns the list of peers who have a given partition. It returns at most


### PR DESCRIPTION
**Summary**
Changes the partition assignment scheme to use a sequential assignment to nodes as opposed to a hash ring. Essentially the same as https://github.com/stripe/sequins/pull/124, except keeping the Shard ID intact which is used to order nodes.

**Motivation**
Will distribute partitions amongst nodes much more uniformly.

r? @scottjab-stripe 
cc? @stripe/storage 

**Note**: Tests for this will not pass until https://github.com/stripe/sequins/pull/127 is merged in as we discovered a bug in the Shard ID logic that caused tests added in this PR to fail. Leaving as WIP until it gets merged, but this has already been tested to work assuming those changes.