### PR TITLE
make db names links to its status, sequins logo a link to the homepage

### DIFF
--- a/status.tmpl
+++ b/status.tmpl
@@ -30,6 +30,15 @@
         line-height: 24px;
       }
 
+      span#logo > a:link, a:visited {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      span#logo > a:hover, a:active {
+        color: white;
+      }
+
       span#docs > a {
         text-decoration: none;
         color: white;
@@ -56,14 +65,13 @@
         box-shadow: 0 4px 6px rgba(50, 50, 93, 0.11), 0 1px 3px rgba(0, 0, 0, 0.08);
       }
 
-      h2.dbname > a.arrow {
-        float: right;
-        margin-right: 5px;
+      h2.dbname > a:link, a:visited {
+        color: inherit;
+        text-decoration: none;
       }
 
-      a.arrow, a.arrow:visited, a.arrow:hover {
-        color: #2b83ba;
-        text-decoration: none;
+      h2.dbname > a:hover, a:active {
+        color: #6772e5;
       }
 
       div.version {
@@ -277,7 +285,7 @@
   <body {{ if not (isListView $) }} onload="drawMaps();" {{ else }} onload="countNodeStatuses();" {{ end }}>
     <div id="header">
       <span id="logo">
-        Sequins!
+        <a href="/">Sequins!</a>
       </span>
 
       <span id="docs">
@@ -291,7 +299,7 @@
       {{ range $dbName, $db := .DBs}}
         {{ if (isListView $) }}
           <div class="db">
-            <h2 class="dbname">/{{ $dbName }} <a class="arrow" href="/{{ $dbName }}">&rarr;</a></h2>
+            <h2 class="dbname"><a href="/{{ $dbName }}">/{{ $dbName }} &rarr;</a></h2>
             {{ range $versionName, $version := $db.Versions }}
               <div class="version">
                 <span class="versionname">/{{ $versionName }}</span>


### PR DESCRIPTION
**Summary**
Makes the db name on the home page a link to it's status. Make the sequins logo a link to the homepage.

**Motivation**
The arrows were hard to click on and easy to miss.

r? @scottjab-stripe 
cc? @stripe/storage 

Link:
<img width="161" alt="screen shot 2017-10-26 at 4 40 31 pm" src="https://user-images.githubusercontent.com/30186826/32081818-702a6e64-ba6c-11e7-8012-821985ee02d5.png">
Hover:
<img width="165" alt="screen shot 2017-10-26 at 4 40 37 pm" src="https://user-images.githubusercontent.com/30186826/32081822-749f3006-ba6c-11e7-8e40-917330bbcf06.png">

