### PR TITLE
remove /healthcheck in favor of /healthz

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -198,7 +198,7 @@ func (tc *testCluster) removeAvailableVersion(version testVersion) {
 }
 
 func (ts *testSequins) getPartitions(version testVersion) []int {
-	url := fmt.Sprintf("http://%s/healthcheck", ts.name)
+	url := fmt.Sprintf("http://%s/healthz", ts.name)
 	res, err := ts.testClient.Get(url)
 	require.NoError(ts, err)
 
@@ -846,7 +846,7 @@ func TestClusterMin(t *testing.T) {
 }
 
 func (ts *testSequins) getShardID(t *testing.T) string {
-	url := fmt.Sprintf("http://%s/healthcheck", ts.name)
+	url := fmt.Sprintf("http://%s/healthz", ts.name)
 
 	resp, err := ts.testClient.Get(url)
 	assert.NoError(t, err)

--- a/doc/manual/1-5-healthchecks-and-monitoring/README.md
+++ b/doc/manual/1-5-healthchecks-and-monitoring/README.md
@@ -21,10 +21,10 @@ with `Accept: application/json`:
             "flights": {
               ...
 
-A simplified healthcheck interface is available at the `/healthz` and
-`/healthcheck` endpoints which will return a JSON representation of the state
-of each node. The status code will either be `200` if at least one version is
-marked as `ACTIVE` or `404` if this isn't the case.
+A simplified healthcheck interface is available at the `/healthz` endpoint
+which will return a JSON representation of the state of each node. The status
+code will either be `200` if at least one version is marked as `ACTIVE` or
+`404` if this isn't the case:
 
     $ http localhost:9599/healthz
     HTTP/1.1 200 OK

--- a/sequins.go
+++ b/sequins.go
@@ -385,7 +385,7 @@ func (s *sequins) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.URL.Path == "/healthcheck" || r.URL.Path == "/healthz" {
+	if r.URL.Path == "/healthz" {
 		s.serveHealth(w, r)
 		return
 	}


### PR DESCRIPTION
The fact that `/healthcheck` clashes with consul will probably cause problems later on.

r? @scottjab-stripe 
cc? @stripe/storage 