### PR TITLE
Display shard IDs on status page

### DIFF
--- a/status.go
+++ b/status.go
@@ -94,6 +94,7 @@ type nodeVersionStatus struct {
 	Current     bool         `json:"current"`
 	State       versionState `json:"state"`
 	Partitions  []int        `json:"partitions"`
+	ShardID     string       `json:"shard_id"`
 }
 
 type versionState string
@@ -424,6 +425,7 @@ func (vs *version) status() versionStatus {
 		CreatedAt:  vs.created.UTC().Truncate(time.Second),
 		State:      vs.state,
 		Partitions: partitions,
+		ShardID:    vs.sequins.config.Sharding.ShardID,
 	}
 
 	if !vs.available.IsZero() {

--- a/status.tmpl
+++ b/status.tmpl
@@ -216,8 +216,11 @@
             var nodeHeight =  Math.floor(totalHeight / (Object.keys(version.nodes).length)),
               partitionWidth = Math.floor(totalWidth / numPartitions);
 
-            var n = 0;
             for (nodeName in version.nodes) {
+              var nodeId = "node_" + dbName + "_" + versionName + "_" + nodeName;
+              var nodeElem = document.getElementById(nodeId);
+              var idx = Array.prototype.indexOf.call(nodeElem.parentElement.children, nodeElem);
+
               var node = version.nodes[nodeName];
 
               if (node.state === "ACTIVE") {
@@ -239,10 +242,8 @@
                 if (node.state !== "BUILDING")
                   replication[p] += 1;
 
-                ctx.fillRect(partitionWidth * p-1, nodeHeight * n, partitionWidth+1, nodeHeight);
+                ctx.fillRect(partitionWidth * p-1, nodeHeight * idx, partitionWidth+1, nodeHeight);
               });
-
-              n += 1;
             }
           }
         }
@@ -316,10 +317,13 @@
                 <div class="versionpath">{{ $version.Path }}</div>
                 <div class="versionwrapper">
                   <div class="nodes">
-                    {{ range $nodeName, $node := $version.Nodes }}
-                      <div class="node {{ if $node.Current }}nodecurrent{{else}}nodenotcurrent{{end}}{{ if eq $node.State "ERROR" }} nodeerror{{end}}">
-                        <div class="nodeid">{{$node.ShardID}}: </div>
-                        <div class="nodename">{{$nodeName}}</div>
+                    {{ range $node := $version.SortedNodes }}
+                      <div class="node {{ if $node.Current }}nodecurrent{{else}}nodenotcurrent{{end}}{{ if eq $node.State "ERROR" }} nodeerror{{end}}"
+                          id="node_{{$dbName}}_{{$versionName}}_{{$node.Name}}">
+                        {{ if ne $node.ShardID "" }}
+                          <div class="nodeid">{{$node.ShardID}}: </div>
+                        {{ end }}
+                        <div class="nodename">{{$node.Name}}</div>
                         <div class="nodestate {{ $node.State }}">{{ $node.State }}</div>
                         <div class="nodetimestamp">
                           {{ if eq $node.State "BUILDING" }}

--- a/status.tmpl
+++ b/status.tmpl
@@ -130,7 +130,7 @@
         color: #fa755a;
       }
 
-      div.nodename {
+      div.nodename, div.nodeid {
         display: inline-block;
         font-weight: bold;
       }
@@ -318,6 +318,7 @@
                   <div class="nodes">
                     {{ range $nodeName, $node := $version.Nodes }}
                       <div class="node {{ if $node.Current }}nodecurrent{{else}}nodenotcurrent{{end}}{{ if eq $node.State "ERROR" }} nodeerror{{end}}">
+                        <div class="nodeid">{{$node.ShardID}}: </div>
                         <div class="nodename">{{$nodeName}}</div>
                         <div class="nodestate {{ $node.State }}">{{ $node.State }}</div>
                         <div class="nodetimestamp">


### PR DESCRIPTION
* Show the shard ID for each node
* Show the nodes in shard-ID order

This should make things like duplicate shard IDs easier to notice.

![image](https://user-images.githubusercontent.com/28717751/32507519-a5a1cb80-c3b5-11e7-8f71-b395a36f9cbf.png)

r? @jerry-stripe 