### PR TITLE
dedup shard IDs when picking local partitions

### DIFF
--- a/doc/manual/2-2-sharding/README.md
+++ b/doc/manual/2-2-sharding/README.md
@@ -95,8 +95,9 @@ backfills them. To do that, it
     a. Creating an array of all partitions in sorted order * the replication
        factor. (e.g. [1, 1, 1, 2, 2, 2, ...])
 
-    b. Creating an array of all nodes it knows about in sorted order based on
-       their shard id.
+    b. Creating an array of all shard ids it knows about in sorted order. If
+       multiple nodes share the same shard id, the shard id will only show up
+       once in the array.
 
     c. For all of the partitions at index `idx`, if `idx % len(nodes)` is equal
        to its position in the node array, we assign it that partition.

--- a/sharding/partitions.go
+++ b/sharding/partitions.go
@@ -90,11 +90,23 @@ func (p *Partitions) pickLocal() {
 				toAssign = append(toAssign, i)
 			}
 		}
-		nodes := append(p.peers.GetShardIds(), p.peers.ShardID)
-		sort.Strings(nodes)
+
+		// only keep unique shardIDs so that nodes with the same
+		// shardID will get the same partition assignments
+		ids := make(map[string]bool)
+		for _, id := range append(p.peers.GetShardIds(), p.peers.ShardID) {
+			ids[id] = true
+		}
+
+		uniqueIds := make([]string, 0, len(ids))
+		for id := range ids {
+			uniqueIds = append(uniqueIds, id)
+		}
+		sort.Strings(uniqueIds)
+
 		for i, id := range toAssign {
-			assignee := i % len(nodes)
-			if nodes[assignee] == p.peers.ShardID {
+			assignee := i % len(uniqueIds)
+			if uniqueIds[assignee] == p.peers.ShardID {
 				selected[id] = true
 			}
 		}


### PR DESCRIPTION
**Summary**
Only consider unique shard IDs when choosing partition assignments.

**Motivation**
This will allow nodes to share partition assignments by using the same shard ID such that one node can replace another in the case of failure.

r? @vasi-stripe 
cc? @stripe/storage 