### PR TITLE
fix exposure of shard id in status page

### DIFF
--- a/status.go
+++ b/status.go
@@ -422,8 +422,10 @@ func (vs *version) status() versionStatus {
 	}
 
 	hostname := "localhost"
+	shardID := ""
 	if vs.sequins.peers != nil {
 		hostname = vs.sequins.address
+		shardID = vs.sequins.peers.ShardID
 	}
 
 	sort.Ints(partitions)
@@ -432,7 +434,7 @@ func (vs *version) status() versionStatus {
 		CreatedAt:  vs.created.UTC().Truncate(time.Second),
 		State:      vs.state,
 		Partitions: partitions,
-		ShardID:    vs.sequins.config.Sharding.ShardID,
+		ShardID:    shardID,
 	}
 
 	if !vs.available.IsZero() {


### PR DESCRIPTION
Completely missed this in https://github.com/stripe/sequins/pull/137, but this just fixes the way we get the ShardID since it can be set by the self_assigned_id file or assigned by smallest misssing.

r? @vasi-stripe 
cc? @stripe/storage 