### PR TITLE
update zk url as the version we use got moved to archives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: go
 go: 1.8.3
 sudo: false
 before_install:
-- wget http://apache.claz.org/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz
+- wget http://archive.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz
 - tar -zxvf zookeeper*tar.gz
 - export NN_PORT=9000
 - export HADOOP_NAMENODE="localhost:$NN_PORT"


### PR DESCRIPTION
**Summary**
Update the zk url, the zk version we use got moved to the archives.

**Motivation**
Travis builds have been failing with this problem: https://travis-ci.org/stripe/sequins/builds/299245524#L484

r? @vasi-stripe 
cc? @stripe/storage 