### PR TITLE
add endpoint to allow sequins to fetch additional partitions for a gi…

### DIFF
--- a/blocks/block_store.go
+++ b/blocks/block_store.go
@@ -105,7 +105,7 @@ func (store *BlockStore) Add(key, value []byte) error {
 
 // Save saves flushes any newly created blocks, and writes a manifest file to
 // the directory.
-func (store *BlockStore) Save(selectedPartitions map[int]bool) error {
+func (store *BlockStore) Save(selectedPartitions []int) error {
 	store.blockMapLock.Lock()
 	defer store.blockMapLock.Unlock()
 
@@ -127,17 +127,11 @@ func (store *BlockStore) Save(selectedPartitions map[int]bool) error {
 	store.newSparkeyBlocks = make(map[int][]*Block)
 
 	// Save the manifest.
-	var partitions []int
-	partitions = make([]int, 0, len(selectedPartitions))
-	for partition := range selectedPartitions {
-		partitions = append(partitions, partition)
-	}
-
 	manifest := Manifest{
 		Version:            manifestVersion,
 		Blocks:             make([]BlockManifest, len(store.Blocks)),
 		NumPartitions:      store.numPartitions,
-		SelectedPartitions: partitions,
+		SelectedPartitions: selectedPartitions,
 	}
 
 	for i, block := range store.Blocks {

--- a/blocks/block_store_test.go
+++ b/blocks/block_store_test.go
@@ -78,7 +78,7 @@ func TestBlockStoreSparkey(t *testing.T) {
 	require.NoError(t, err)
 	err = store.AddSparkeyBlock(nonEmpty0, 0)
 	require.NoError(t, err)
-	err = store.Save(map[int]bool{0: true, 1: true})
+	err = store.Save([]int{0, 1})
 	require.NoError(t, err)
 
 	// Internal properties
@@ -134,7 +134,7 @@ func TestBlockStoreSparkey(t *testing.T) {
 	err = store.AddSparkeyBlock(revertBlock, 0)
 	require.NoError(t, err)
 	store.Revert()
-	err = store.Save(map[int]bool{0: true, 1: true})
+	err = store.Save([]int{0, 1})
 	require.NoError(t, err)
 	rec, err = store.Get("Alice")
 	assert.NoError(t, err)

--- a/build.go
+++ b/build.go
@@ -50,13 +50,13 @@ func compressionCodecString(c sequencefile.CompressionCodec) string {
 	}
 }
 
-func (vs *version) build() {
+func (vs *version) build(rebuild bool) {
 	// Welcome to the sequins museum of lock acquisition. First, we grab the lock
 	// for this version, and check that the previous holder didn't finish
 	// building.
 	vs.buildLock.Lock()
 	defer vs.buildLock.Unlock()
-	if vs.built {
+	if !rebuild && vs.built {
 		return
 	}
 
@@ -159,7 +159,7 @@ func (vs *version) addFiles(partitions map[int]bool) error {
 	case err := <-errs:
 		return err
 	case <-c:
-		return vs.blockStore.Save(vs.partitions.SelectedLocal())
+		return vs.blockStore.Save(vs.partitions.Selected())
 	}
 }
 

--- a/db.go
+++ b/db.go
@@ -122,7 +122,7 @@ func (db *db) refresh() error {
 	if existingVersion != nil {
 		// If the build succeeded or is in progress, this is a noop. If it errored
 		// before, this will retry.
-		go existingVersion.build()
+		go existingVersion.build(false)
 		return nil
 	}
 
@@ -144,7 +144,7 @@ func (db *db) switchVersion(version *version) bool {
 	db.mux.prepare(version)
 
 	// Build any partitions we're missing in the background.
-	go version.build()
+	go version.build(false)
 
 	// Start advertising our partitions to peers.
 	go version.partitions.Advertise()

--- a/sequins.go
+++ b/sequins.go
@@ -28,6 +28,8 @@ import (
 
 const defaultMaxLoads = 10
 
+const localhost = "127.0.0.1"
+
 // While we wait to pick a shard ID, other nodes are prohibited from joining the cluster because
 // we're holding a lock. This timeout can therefore be pretty short.
 //
@@ -375,6 +377,11 @@ func (s *sequins) refreshAll() {
 }
 
 func (s *sequins) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/fetch" && strings.HasPrefix(r.RemoteAddr, localhost) && r.Method == "POST" {
+		s.serveFetch(w, r)
+		return
+	}
+
 	if r.Method != "GET" {
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/sharding/partitions.go
+++ b/sharding/partitions.go
@@ -28,7 +28,7 @@ type Partitions struct {
 	version string
 	zkPath  string
 
-	numPartitions int
+	NumPartitions int
 	replication   int
 
 	// The minimum replication to stop counting a partition as "missing".
@@ -54,9 +54,10 @@ func WatchPartitions(zkWatcher *zk.Watcher, peers *Peers, db, version string, nu
 		db:             db,
 		version:        version,
 		zkPath:         path.Join("partitions", db, version),
-		numPartitions:  numPartitions,
+		NumPartitions:  numPartitions,
 		replication:    replication,
 		minReplication: minReplication,
+		selected:       make(map[int]bool),
 		local:          make(map[int]bool),
 		remote:         make(map[int][]string),
 	}
@@ -77,15 +78,15 @@ func WatchPartitions(zkWatcher *zk.Watcher, peers *Peers, db, version string, nu
 // in order, each repeated by the target replication, and sequentially assigning each
 // partition to a node.
 func (p *Partitions) pickLocal() {
-	selected := make(map[int]bool, p.numPartitions)
+	selected := make(map[int]bool, p.NumPartitions)
 
 	if p.peers == nil {
-		for i := 0; i < p.numPartitions; i++ {
+		for i := 0; i < p.NumPartitions; i++ {
 			selected[i] = true
 		}
 	} else {
-		toAssign := make([]int, 0, p.numPartitions*p.replication)
-		for i := 0; i < p.numPartitions; i++ {
+		toAssign := make([]int, 0, p.NumPartitions*p.replication)
+		for i := 0; i < p.NumPartitions; i++ {
 			for j := 0; j < p.replication; j++ {
 				toAssign = append(toAssign, i)
 			}
@@ -111,7 +112,8 @@ func (p *Partitions) pickLocal() {
 			}
 		}
 	}
-	p.selected = selected
+
+	p.SetSelected(selected)
 }
 
 // sync runs in the background, and syncs the remote partitions from zookeeper
@@ -141,7 +143,29 @@ func (p *Partitions) FindPeers(partition int) []string {
 	return peers
 }
 
-// Update updates the list of local partitions to the given list.
+// SetSelected sets the list of selected partitions to the one given.
+func (p *Partitions) SetSelected(selected map[int]bool) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.selected = make(map[int]bool)
+	for partition, sel := range selected {
+		p.selected[partition] = sel
+	}
+}
+
+// UpdateSelected udpates the list of selected partitions to include the given
+// list.
+func (p *Partitions) UpdateSelected(selected map[int]bool) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	for partition, sel := range selected {
+		p.selected[partition] = sel
+	}
+}
+
+// UpdateLocal updates the list of local partitions to include the given list.
 func (p *Partitions) UpdateLocal(local map[int]bool) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
@@ -158,10 +182,42 @@ func (p *Partitions) UpdateLocal(local map[int]bool) {
 	}
 }
 
-// SelectedLocal returns the set of partitions that were selected to have
+// Selected returns the set of partitions that were selected to have
 // locally.
-func (p *Partitions) SelectedLocal() map[int]bool {
-	return p.selected
+func (p *Partitions) Selected() []int {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	selected := make([]int, 0, len(p.selected))
+	for partition, sel := range p.selected {
+		if sel {
+			selected = append(selected, partition)
+		}
+	}
+	return selected
+}
+
+// HaveSelected returns true if the partitions is selected to be available
+// locally.
+func (p *Partitions) HaveSelected(partition int) bool {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	return p.selected[partition]
+}
+
+// Local returns the set of partitions that are in the blockstore.
+func (p *Partitions) Local() []int {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	local := make([]int, 0, len(p.local))
+	for partition, sel := range p.local {
+		if sel {
+			local = append(local, partition)
+		}
+	}
+	return local
 }
 
 // NeededLocal returns the set of partitions that were selected to have locally,
@@ -247,7 +303,7 @@ func (p *Partitions) updateReplicationStatus() {
 	// Check for each partition. If every one is available on at least minReplication node,
 	// then we're ready to rumble.
 	missing := 0
-	for i := 0; i < p.numPartitions; i++ {
+	for i := 0; i < p.NumPartitions; i++ {
 		replication := 0
 		if _, ok := p.local[i]; ok {
 			replication++

--- a/status.go
+++ b/status.go
@@ -229,6 +229,56 @@ func (s *sequins) serveStatus(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+type fetchRequest map[string]map[string][]int
+
+func (s *sequins) serveFetch(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	decoder := json.NewDecoder(r.Body)
+
+	var fetchReq fetchRequest
+	err := decoder.Decode(&fetchReq)
+	if err != nil {
+		log.Printf("Error parsing json body of fetchRequest: %s", err.Error())
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// Iterate through all db/versions, fetching the specified partitions
+	// and skipping the ones that don't exist.
+	for dbName, versions := range fetchReq {
+		db, ok := s.dbs[dbName]
+		if !ok {
+			log.Printf("Skipping nonexistent db: %s...", dbName)
+			continue
+		}
+
+		for versionName, partitions := range versions {
+			version := db.mux.getVersion(versionName)
+			if version == nil {
+				log.Printf("Skipping nonexistent version %s in db %s...", versionName, dbName)
+				continue
+			}
+
+			log.Printf("Requesting partitions %v for %s/%s...", partitions, dbName, versionName)
+
+			// Filter out partitions that can't exist and those
+			// that are already local to avoid needless fetching.
+			partitionMap := make(map[int]bool, len(partitions))
+			for _, p := range partitions {
+				validPartition := p >= 0 && p < version.partitions.NumPartitions
+				existingPartition := version.partitions.HaveSelected(p) && version.partitions.HaveLocal(p)
+
+				if validPartition && !existingPartition {
+					partitionMap[p] = true
+				}
+			}
+
+			version.partitions.UpdateSelected(partitionMap)
+			go version.build(true)
+		}
+	}
+}
+
 func (db *db) serveStatus(w http.ResponseWriter, r *http.Request) {
 	s := db.status()
 
@@ -415,11 +465,6 @@ func (vs *version) status() versionStatus {
 		TargetReplication:    vs.sequins.config.Sharding.Replication,
 	}
 
-	partitions := make([]int, 0, len(vs.partitions.SelectedLocal()))
-	for p := range vs.partitions.SelectedLocal() {
-		partitions = append(partitions, p)
-	}
-
 	hostname := "localhost"
 	shardID := ""
 	if vs.sequins.peers != nil {
@@ -427,7 +472,9 @@ func (vs *version) status() versionStatus {
 		shardID = vs.sequins.peers.ShardID
 	}
 
+	partitions := vs.partitions.Selected()
 	sort.Ints(partitions)
+
 	nodeStatus := nodeVersionStatus{
 		Name:       hostname,
 		CreatedAt:  vs.created.UTC().Truncate(time.Second),


### PR DESCRIPTION
**Summary**
Add the `/fetch` endpoint (only accessible from `localhost`) that can be used to tell sequins to fetch the given partitions by sending a POST request with a JSON payload of the given form:
```
{
    "db1": {
        "version1": [1,2,3,4,5,6],
        "version2": [1,2,3,4,5,6]
    },

    "db2": {
        "version1": [1,2,3,4,5,6]
    }
}
```
If the request fails in any way, an InternalServerError (500) is returned, otherwise a 200 is returned. Additionally, nonexistent db/version pairs will be ignored rather than causing an error.

This also fixes the fact that the getters for the selected partitions would return the reference to the internal map ([here](https://github.com/stripe/sequins/compare/jerry-fetch?expand=1#diff-76451cb05f1dcf66ac577e04ec386a7dR147)). And the fact that this map was used in a way that assumed all of the values were `true` ([example](https://github.com/stripe/sequins/compare/jerry-fetch?expand=1#diff-493095f7c1f1cc2111c53a48c8823a99L130))

**Motivation**
This endpoint will allow us to implement a way to tell a sequins cluster to pick up under-replicated partitions.

**Concerns**
I've noticed the distinction between selected partitions and local partitions. I'm not sure if this is still a distinction that we feel strongly about but it causes the following behavior: 

Partitions grabbed through this method will persist between reboots of sequins and thus continue to take up disk space, despite the fact that they won't stay "selected". This is because upon starting up, sequins will pick the selected partitions based on its partition assignment, regardless of what it currently has. We might want to either, let sequins serve everything it has on disk (which is probably not a good idea as nodes will take a lot of traffic instead of proxying), or keep track of partitions fetched through this method and clean them up upon shutdown.

**Testing**
Tested against local sequins cluster and dummysequins.

r? @vasi-stripe, @scottjab-stripe 
cc? @stripe/storage 