### PR TITLE
add max_replication to config to allow for a partition replication limit

### DIFF
--- a/config.go
+++ b/config.go
@@ -53,6 +53,7 @@ type shardingConfig struct {
 	Enabled            bool     `toml:"enabled"`
 	Replication        int      `toml:"replication"`
 	MinReplication     int      `toml:"min_replication"`
+	MaxReplication     int      `toml:"max_replication"`
 	TimeToConverge     duration `toml:"time_to_converge"`
 	ProxyTimeout       duration `toml:"proxy_timeout"`
 	ProxyStageTimeout  duration `toml:"proxy_stage_timeout"`
@@ -115,6 +116,7 @@ func defaultConfig() sequinsConfig {
 			Enabled:            false,
 			Replication:        2,
 			MinReplication:     1,
+			MaxReplication:     0,
 			TimeToConverge:     duration{10 * time.Second},
 			ProxyTimeout:       duration{100 * time.Millisecond},
 			ProxyStageTimeout:  duration{time.Duration(0)},

--- a/doc/manual/x-1-configuration-reference/README.md
+++ b/doc/manual/x-1-configuration-reference/README.md
@@ -174,6 +174,22 @@ upgrading.
 You probably don't want this to be equal to `replication`,
 or sequins will never upgrade versions if any node at all is down.
 
+### max_replication
+Type | Default
+:--: | -------
+int  | 0 (disabled)
+
+This is the maximum number of replicas that sequins will allow to exist for a
+given partition. This can come into play if ZK starts flapping while nodes
+are coming online, causing partition assignments to be inconsistent. You
+probably don't want this to be equal to `replication` as it will make it hard
+to replace a node that is having issues (since the replacement node will see
+all partitions as already properly replicated and refuse to fetch them
+again).
+
+A value of less than `replication` means that `max_replication` is
+ignored and no limit is imposed.
+
 ### time_to_converge
 
 Type   | Default

--- a/sequins.conf.example
+++ b/sequins.conf.example
@@ -87,6 +87,17 @@ source = "hdfs://namenode:8020/path/to/sequins"
 # You probably don't want this to be equal to `replication`,
 # or sequins will never upgrade versions if any node at all is down.
 
+# max_replication = 0
+# This is the maximum number of replicas that sequins will allow to exist for a
+# given partition. This can come into play if ZK starts flapping while nodes
+# are coming online, causing partition assignments to be inconsistent. You
+# probably don't want this to be equal to `replication` as it will make it hard
+# to replace a node that is having issues (since the replacement node will see
+# all partitions as already properly replicated and refuse to fetch them
+# again).
+# A value of less than `replication` means that `max_replication` is
+# ignored and no limit is imposed.
+
 # time_to_converge = "10s"
 # Upon startup, sequins will wait this long for the set of known peers to
 # stabilize.

--- a/version.go
+++ b/version.go
@@ -78,12 +78,14 @@ func newVersion(sequins *sequins, db *db, path, name string) (*version, error) {
 	}
 
 	minReplication := 1
+	maxReplication := 0
 	if sequins.config.Sharding.Enabled {
 		minReplication = sequins.config.Sharding.MinReplication
+		maxReplication = sequins.config.Sharding.MaxReplication
 	}
 
 	vs.partitions = sharding.WatchPartitions(sequins.zkWatcher, sequins.peers,
-		db.name, name, vs.numPartitions, sequins.config.Sharding.Replication, minReplication)
+		db.name, name, vs.numPartitions, sequins.config.Sharding.Replication, minReplication, maxReplication)
 
 	err = vs.initBlockStore(path)
 	if err != nil {


### PR DESCRIPTION
**Summary**
Add a new config option, `max_replication` that will limit the replication factor of partitions. For a given node, when choosing which partitions it should have locally, it will first ensure that selecting a partition wouldn't bring it over this value. If it would, it doesn't select it. `max_replication` is only respected if `max_replication <= replication`, so setting it to 0 will disable this feature.

**Motivation**
This will limit the damage of ZK flapping such that nodes don't fill up too rapidly.

**Testing**
Unit testing for now. Will test in QA as well.

r? @scottjab-stripe 
cc? @stripe/storage 