### PR TITLE
lock access to p.selected

### DIFF
--- a/blocks/block_store.go
+++ b/blocks/block_store.go
@@ -105,7 +105,7 @@ func (store *BlockStore) Add(key, value []byte) error {
 
 // Save saves flushes any newly created blocks, and writes a manifest file to
 // the directory.
-func (store *BlockStore) Save(selectedPartitions map[int]bool) error {
+func (store *BlockStore) Save(partitions []int) error {
 	store.blockMapLock.Lock()
 	defer store.blockMapLock.Unlock()
 
@@ -127,12 +127,6 @@ func (store *BlockStore) Save(selectedPartitions map[int]bool) error {
 	store.newSparkeyBlocks = make(map[int][]*Block)
 
 	// Save the manifest.
-	var partitions []int
-	partitions = make([]int, 0, len(selectedPartitions))
-	for partition := range selectedPartitions {
-		partitions = append(partitions, partition)
-	}
-
 	manifest := Manifest{
 		Version:            manifestVersion,
 		Blocks:             make([]BlockManifest, len(store.Blocks)),

--- a/blocks/block_store_test.go
+++ b/blocks/block_store_test.go
@@ -78,7 +78,7 @@ func TestBlockStoreSparkey(t *testing.T) {
 	require.NoError(t, err)
 	err = store.AddSparkeyBlock(nonEmpty0, 0)
 	require.NoError(t, err)
-	err = store.Save(map[int]bool{0: true, 1: true})
+	err = store.Save([]int{0, 1})
 	require.NoError(t, err)
 
 	// Internal properties
@@ -134,7 +134,7 @@ func TestBlockStoreSparkey(t *testing.T) {
 	err = store.AddSparkeyBlock(revertBlock, 0)
 	require.NoError(t, err)
 	store.Revert()
-	err = store.Save(map[int]bool{0: true, 1: true})
+	err = store.Save([]int{0, 1})
 	require.NoError(t, err)
 	rec, err = store.Get("Alice")
 	assert.NoError(t, err)

--- a/build.go
+++ b/build.go
@@ -159,7 +159,7 @@ func (vs *version) addFiles(partitions map[int]bool) error {
 	case err := <-errs:
 		return err
 	case <-c:
-		return vs.blockStore.Save(vs.partitions.SelectedLocal())
+		return vs.blockStore.Save(vs.partitions.Selected())
 	}
 }
 

--- a/status.go
+++ b/status.go
@@ -386,11 +386,6 @@ func (vs *version) status() versionStatus {
 		TargetReplication:    vs.sequins.config.Sharding.Replication,
 	}
 
-	partitions := make([]int, 0, len(vs.partitions.SelectedLocal()))
-	for p := range vs.partitions.SelectedLocal() {
-		partitions = append(partitions, p)
-	}
-
 	hostname := "localhost"
 	shardID := ""
 	if vs.sequins.peers != nil {
@@ -398,7 +393,9 @@ func (vs *version) status() versionStatus {
 		shardID = vs.sequins.peers.ShardID
 	}
 
+	partitions := vs.partitions.Selected()
 	sort.Ints(partitions)
+
 	nodeStatus := nodeVersionStatus{
 		Name:       hostname,
 		CreatedAt:  vs.created.UTC().Truncate(time.Second),


### PR DESCRIPTION
**Summary**
Protect access to `p.selected` with a lock, and also have the wrapper function return a alice since both consumers convert to a slice anyways.

r? @scottjab-stripe 
cc? @stripe/storage 