### PR TITLE
Restore S3 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,9 @@ deploy:
     all_branches: true
 env:
   global:
-    # Region
-    - secure: "giM8b/a4JfCDh6cpUyKo1uNUlNXZ28/PN3fnIN28s2GGvuipRCv+8BiqyxG6ukwPyQluHNxpsRcLFeXG2noSelHXY4HwdYZY5bDZ2xiWHTudphQD7gnQMoa8jSOx/66rLjMmx5UmtzlYfmsY9Rw1SshORWlgBmMeIYNWYu1NJiw="
+  # Region
+  - secure: giM8b/a4JfCDh6cpUyKo1uNUlNXZ28/PN3fnIN28s2GGvuipRCv+8BiqyxG6ukwPyQluHNxpsRcLFeXG2noSelHXY4HwdYZY5bDZ2xiWHTudphQD7gnQMoa8jSOx/66rLjMmx5UmtzlYfmsY9Rw1SshORWlgBmMeIYNWYu1NJiw=
+  # Test bucket
+  - secure: zBxttvSia8TL43USnZuVP9btWyXDFMm7N3fspFrL1+iJlZbWT/2d3MRtBbKc29NTeKwYcrh/b1N64lM5X2RR4tGZ0T+Qms7RzGQEiUmkEqbn5JVVqvXBBBSkGv5hVNaZjHkYW4ZwUe6u278k+LDTNsydtNA8gWy1PZUV/kRtOH4=
+  # AWS credentials
+  - secure: dDWX4mBi03Qpz0hPsc0+4sQdJNfqMyuuJPE+S91Ij1nQJn6mLcNwJnXP6CJ2nyM/UPav0L1p4zraKDn5R8V0Y7mPrPmISte6ZNJ/n7avfaX9f4WjrF3cOicCwIYqIxUN05p4ciQVbsRiceee7Uf7DmhtF0baF3CvzmPBq6gcoNk=

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 - sh vendor/github.com/colinmarc/hdfs/setup_test_env.sh
 before_script:
 - make
-script: make test test_functional vet
+script: make VERBOSE=1 test test_functional vet
 before_deploy: make release
 cache:
   directories:

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ else
 	CGO_PREAMBLE_LDFLAGS = -lrt -lm -lstdc++
 endif
 
+ifneq ($(VERBOSE),)
+  VERBOSITY=-v
+endif
+
 CGO_PREAMBLE = CGO_CFLAGS="-I$(BUILD)/include -I$(BUILD)/include/zookeeper" CGO_LDFLAGS="$(VENDORED_LIBS) $(CGO_PREAMBLE_LDFLAGS)"
 
 
@@ -63,16 +67,16 @@ release: sequins
 	tar -cvzf $(RELEASE_NAME).tar.gz $(RELEASE_NAME)
 
 test: $(TEST_SOURCES)
-	$(CGO_PREAMBLE) go test -short -race -timeout 2m $(shell go list ./... | grep -v vendor)
+	$(CGO_PREAMBLE) go test $(VERBOSITY) -short -race -timeout 2m $(shell go list ./... | grep -v vendor)
 	# This test exercises some sync.Pool code, so it should be run without -race
 	# as well (sync.Pool doesn't ever share objects under -race).
-	$(CGO_PREAMBLE) go test -timeout 30s ./blocks -run TestBlockParallelReads
+	$(CGO_PREAMBLE) go test $(VERBOSITY) -timeout 30s ./blocks -run TestBlockParallelReads
 
 vet:
 	$(CGO_PREAMBLE) go vet $(shell go list ./... | grep -v vendor)
 
 test_functional: sequins $(TEST_SOURCES)
-	$(CGO_PREAMBLE) go test -timeout 10m -run "^TestCluster"
+	$(CGO_PREAMBLE) go test $(VERBOSITY) -timeout 10m -run "^TestCluster"
 
 clean:
 	rm -rf $(BUILD)


### PR DESCRIPTION
Restore S3 tests, now that we have a good S3 test account again.

Also run tests verbosely, so that we can actually tell that S3 tests are running and not skipped.