### PR TITLE
Die if sequins is ZK-flapping

### DIFF
--- a/zk/watcher_test.go
+++ b/zk/watcher_test.go
@@ -1,6 +1,7 @@
 package zk
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"testing"
@@ -12,10 +13,12 @@ import (
 	"github.com/stripe/sequins/zk/zktest"
 )
 
-func connectTest(t *testing.T) (*Watcher, *zk.TestCluster) {
+const defaultReconnect = 5 * time.Second
+
+func connectTest(t *testing.T, reconnect time.Duration) (*Watcher, *zk.TestCluster) {
 	tzk := zktest.New(t)
 
-	zkWatcher, err := Connect([]string{fmt.Sprintf("localhost:%d", tzk.Servers[0].Port)}, "/sequins-test", 5*time.Second, 5*time.Second)
+	zkWatcher, err := Connect([]string{fmt.Sprintf("localhost:%d", tzk.Servers[0].Port)}, "/sequins-test", 5*time.Second, reconnect)
 	require.NoError(t, err, "zkWatcher should connect")
 
 	return zkWatcher, tzk
@@ -34,7 +37,7 @@ func expectWatchUpdate(t *testing.T, expected []string, updates chan []string, m
 }
 
 func TestZKWatcher(t *testing.T) {
-	w, tzk := connectTest(t)
+	w, tzk := connectTest(t, defaultReconnect)
 	defer w.Close()
 	defer tzk.Stop()
 
@@ -51,7 +54,7 @@ func TestZKWatcher(t *testing.T) {
 }
 
 func TestZKWatcherReconnect(t *testing.T) {
-	w, tzk := connectTest(t)
+	w, tzk := connectTest(t, defaultReconnect)
 	defer w.Close()
 	defer tzk.Stop()
 
@@ -85,7 +88,7 @@ func TestZKWatchesCanceled(t *testing.T) {
 }
 */
 func TestZKRemoveWatch(t *testing.T) {
-	w, tzk := connectTest(t)
+	w, tzk := connectTest(t, defaultReconnect)
 	defer w.Close()
 	defer tzk.Stop()
 
@@ -125,5 +128,47 @@ func TestZKRemoveWatch(t *testing.T) {
 	case <-closed:
 	case <-timer.C:
 		assert.Fail(t, "the disconnected channel should be closed")
+	}
+}
+
+func simulateError(w *Watcher) {
+	sendErr("testing errors", w.errs, errors.New("test error"), "test path", "test server")
+	// Wait for reconnect
+	time.Sleep(25 * time.Millisecond)
+}
+
+func TestZKFlapping(t *testing.T) {
+	w, tzk := connectTest(t, 10*time.Millisecond)
+	defer tzk.Stop()
+	defer w.Close()
+
+	flapNotify := w.SetFlapThreshold(5, time.Second)
+
+	for i := 0; i < 4; i++ {
+		simulateError(w)
+	}
+	select {
+	case <-flapNotify:
+		assert.Fail(t, "Small number of flaps should not trigger notification")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	time.Sleep(time.Second)
+	for i := 0; i < 4; i++ {
+		simulateError(w)
+	}
+	select {
+	case <-flapNotify:
+		assert.Fail(t, "Flaps should expire")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	for i := 0; i < 5; i++ {
+		simulateError(w)
+	}
+	select {
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "Flaps in a short period should notify")
+	case <-flapNotify:
 	}
 }


### PR DESCRIPTION
Our service runner should then restart sequins, allowing us to successfully reconnect. Yes, this is ugly :(

Also add some extra debugging info to our ZK watcher.