### PR TITLE
Use a feature flag to control fetching versions

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -127,13 +127,6 @@ func shardID(id string) configOption {
 	}
 }
 
-func featureFlags(file *os.File) configOption {
-	return func(config *sequinsConfig) {
-		config.GoforitFlagJsonPath = file.Name()
-		config.Sharding.ClusterName = ""
-	}
-}
-
 func (tc *testCluster) addSequins(opts ...configOption) *testSequins {
 	port := zktest.RandomPort()
 	path := filepath.Join(tc.source, fmt.Sprintf("node-%d", port))

--- a/config.go
+++ b/config.go
@@ -36,6 +36,7 @@ type sequinsConfig struct {
 	Debug    debugConfig    `toml:"debug"`
 	Test     testConfig     `toml:"test"`
 	Datadog  datadogConfig  `toml:"datadog"`
+	Goforit  goforitConfig  `toml:"goforit"`
 }
 
 type storageConfig struct {
@@ -92,6 +93,10 @@ type testConfig struct {
 
 type datadogConfig struct {
 	Url string `toml:"url"`
+}
+
+type goforitConfig struct {
+	RemoteRefreshFlagJsonPath string `toml:"remote_refresh_flag_path"`
 }
 
 func defaultConfig() sequinsConfig {

--- a/config.go
+++ b/config.go
@@ -28,6 +28,7 @@ type sequinsConfig struct {
 	RequireSuccessFile              bool     `toml:"require_success_file"`
 	ContentType                     string   `toml:"content_type"`
 	MaxDownloadBandwidthMBPerSecond int      `toml:"max_download_bandwidth_mb_per_second"`
+	GoforitFlagJsonPath             string   `toml:"goforit_flag_json_path"`
 
 	Storage  storageConfig  `toml:"storage"`
 	S3       s3Config       `toml:"s3"`
@@ -36,7 +37,6 @@ type sequinsConfig struct {
 	Debug    debugConfig    `toml:"debug"`
 	Test     testConfig     `toml:"test"`
 	Datadog  datadogConfig  `toml:"datadog"`
-	Goforit  goforitConfig  `toml:"goforit"`
 }
 
 type storageConfig struct {
@@ -93,10 +93,6 @@ type testConfig struct {
 
 type datadogConfig struct {
 	Url string `toml:"url"`
-}
-
-type goforitConfig struct {
-	RemoteRefreshFlagJsonPath string `toml:"remote_refresh_flag_path"`
 }
 
 func defaultConfig() sequinsConfig {

--- a/db.go
+++ b/db.go
@@ -72,7 +72,7 @@ func (db *db) backfillVersions(initialLocal bool) error {
 	var versions []string
 	var err error
 	if initialLocal {
-		log.Printf("Initial fetch of local versions only: db=%s\n", db.name)
+		log.Printf("Initial fetch of local versions only: db=%s", db.name)
 		versions, err = db.localVersions()
 	} else {
 		versions, err = db.listVersions("")

--- a/db.go
+++ b/db.go
@@ -72,7 +72,7 @@ func (db *db) backfillVersions(initialLocal bool) error {
 	var versions []string
 	var err error
 	if initialLocal {
-		log.Printf("Initial fetch of local versions only: db=%s", db.name)
+		log.Printf("Initial fetch of local versions only: db=%q", db.name)
 		versions, err = db.localVersions()
 	} else {
 		versions, err = db.listVersions("")

--- a/db.go
+++ b/db.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"time"
 
@@ -45,16 +46,37 @@ func (db *db) listVersions(after string) ([]string, error) {
 	return filterPaths(versions), nil
 }
 
+func (db *db) localVersions() ([]string, error) {
+	files, err := ioutil.ReadDir(db.localPathDir())
+	if err != nil {
+		return nil, err
+	}
+
+	var versions []string
+	for _, f := range files {
+		versions = append(versions, f.Name())
+	}
+	sort.Strings(versions)
+	return versions, nil
+}
+
 // backfillVersions is called at startup, and tries to grab any versions that
 // are either downloaded locally or available entirely at peers. This allows a
 // node to join a cluster with an existing version all set to go, and start up
 // serving that version (but exclusively proxy it). It also allows it to start
 // up with stale data, even if there's newer data available.
-func (db *db) backfillVersions() error {
+func (db *db) backfillVersions(initialLocal bool) error {
 	db.refreshLock.Lock()
 	defer db.refreshLock.Unlock()
 
-	versions, err := db.listVersions("")
+	var versions []string
+	var err error
+	if initialLocal {
+		log.Printf("Initial fetch of local versions only: db=%s\n", db.name)
+		versions, err = db.localVersions()
+	} else {
+		versions, err = db.listVersions("")
+	}
 	if err != nil {
 		return err
 	} else if len(versions) == 0 {
@@ -281,7 +303,11 @@ func (db *db) cleanupStore() {
 // localPath returns the path where local data for the given version should be
 // stored.
 func (db *db) localPath(version string) string {
-	return filepath.Join(db.sequins.config.LocalStore, "data", db.name, version)
+	return filepath.Join(db.localPathDir(), version)
+}
+
+func (db *db) localPathDir() string {
+	return filepath.Join(db.sequins.config.LocalStore, "data", db.name)
 }
 
 func (db *db) serveKey(w http.ResponseWriter, r *http.Request, key string) {

--- a/doc/manual/x-1-configuration-reference/README.md
+++ b/doc/manual/x-1-configuration-reference/README.md
@@ -95,6 +95,24 @@ string | _unset_ (eg `"application/json"`)
 
 If this is set, sequins will set this Content-Type header on responses.
 
+### goforit_flag_json_path
+
+Type   | Default
+:----: | -------
+string | _unset_
+
+If this path is specified, sequins will start goforit backed by the
+JSON file located at that path.  Goforit enables feature flagging
+within sequins and can be used to easily toggle remote refresh on
+and off.  Before each remote refresh, sequins will inspect this file for
+the state of the flag sequins.prevent_download (or sequins.prevent_download
+.<CLUSTER NAME> if the instance is part of a cluster).  If the flag is
+not defined or is set to FALSE, remote refresh will proceed as expected.
+If it's set to TRUE, sequins will not refresh from remote.
+
+If the flag is TRUE on initial startup, sequins will backfill versions
+from the local store and serve the most recent version available there.
+
 ## [storage]
 
 ### compression

--- a/doc/manual/x-1-configuration-reference/README.md
+++ b/doc/manual/x-1-configuration-reference/README.md
@@ -101,7 +101,7 @@ Type   | Default
 :----: | -------
 string | _unset_
 
-If this path is specified, sequins will start goforit backed by the
+If this path is specified, sequins will start [Goforit][goforit] backed by the
 JSON file located at that path.  Goforit enables feature flagging
 within sequins and can be used to easily toggle remote refresh on
 and off.  Before each remote refresh, sequins will inspect this file for
@@ -344,3 +344,4 @@ If set, this adds the default pprof handlers to the debug HTTP server.
 [toml]: https://github.com/toml-lang/toml
 [confexample]: https://github.com/stripe/sequins/blob/master/sequins.conf.example
 [dogstatsd]: https://docs.datadoghq.com/guides/dogstatsd/
+[goforit]: https://github.com/stripe/goforit

--- a/sequins.conf.example
+++ b/sequins.conf.example
@@ -46,12 +46,12 @@ source = "hdfs://namenode:8020/path/to/sequins"
 # Unset by default. If this is set, sequins will set this Content-Type header on
 # responses.
 
-# goforit_flag_json_path = "/pay/cache/infra_feature_flags.json"
+# goforit_flag_json_path = "/path/to/flags.json"
 # Unset by default. If this path is specified, sequins will
 # start goforit backed by the JSON file located at that path.
 # Goforit enables feature flagging within sequins and can be used
-# to easily toggle remote refresh on and off.  See disableRemoteRefreshFlagPrefix
-# in sequins.go for more details.
+# to easily toggle remote refresh on and off.  See
+# disableRemoteRefreshFlagPrefix in sequins.go for more details.
 
 [storage]
 

--- a/sequins.conf.example
+++ b/sequins.conf.example
@@ -46,6 +46,13 @@ source = "hdfs://namenode:8020/path/to/sequins"
 # Unset by default. If this is set, sequins will set this Content-Type header on
 # responses.
 
+# goforit_flag_json_path = "/pay/cache/infra_feature_flags.json"
+# Unset by default. If this path is specified, sequins will
+# start goforit backed by the JSON file located at that path.
+# Goforit enables feature flagging within sequins and can be used
+# to easily toggle remote refresh on and off.  See disableRemoteRefreshFlagPrefix
+# in sequins.go for more details.
+
 [storage]
 
 # compression = "snappy"

--- a/sequins.go
+++ b/sequins.go
@@ -125,12 +125,12 @@ func (s *sequins) init() error {
 	}
 
 	// Kick off feature flag cache refresh if remote refresh toggle path configured
-  if s.config.Goforit != nil {
+	if s.config.Goforit != nil {
 		log.Printf("Enabling Goforit backed by %s in %s",
 			s.config.Goforit.RemoteRefreshFlagJsonPath, s.config.Sharding.ShardID)
-    backend := goforit.BackendFromJSONFile(s.config.Goforit.RemoteRefreshFlagJsonPath)
-    goforit.Init(30*time.Second, backend)
-  }
+		backend := goforit.BackendFromJSONFile(s.config.Goforit.RemoteRefreshFlagJsonPath)
+		goforit.Init(30*time.Second, backend)
+	}
 
 	// Trigger loads before we start up.
 	s.refreshAll(!s.remoteRefresh())
@@ -172,14 +172,14 @@ func (s *sequins) init() error {
 
 func (s *sequins) remoteRefresh(trigger string) bool {
 	flagName := disableRemoteRefreshFlagPrefix + s.config.Sharding.ClusterName
-  if s.config.Goforit != nil && goforit.Enabled(flagName) {
-    log.Printf("Not allowing remote refresh %s in cluster %s because flag %s is
-			enabled", s.config.Sharding.ShardID, s.config.Sharding.ClusterName, flagName)
+	if s.config.Goforit != nil && goforit.Enabled(flagName) {
+		log.Printf("Not allowing remote refresh %s in cluster %s because flag %s is"+
+			"enabled", s.config.Sharding.ShardID, s.config.Sharding.ClusterName, flagName)
 		s.stats.Count(flagName, 1, []string{"trigger:" + trigger}, 1.0)
 		return false
-  } else {
+	} else {
 		return true
-  }
+	}
 }
 
 func (s *sequins) ensureShardID(zkWatcher *zk.Watcher, routableIpAddress string) (*sharding.Peers, error) {

--- a/sequins.go
+++ b/sequins.go
@@ -131,7 +131,7 @@ func (s *sequins) init() error {
 
 	// Kick off feature flag cache refresh if GoforitFlagJsonPath configured
 	if s.config.GoforitFlagJsonPath != "" {
-		log.Printf("Enabling Goforit: GoforitFlagJsonPath=%s", s.config.GoforitFlagJsonPath)
+		log.Printf("Enabling Goforit: GoforitFlagJsonPath=%q", s.config.GoforitFlagJsonPath)
 		s.goforit = goforit.BackendFromJSONFile(s.config.GoforitFlagJsonPath)
 		goforit.Init(goforitRefresh, s.goforit)
 	}
@@ -162,7 +162,7 @@ func (s *sequins) init() error {
 			if s.goforit != nil {
 				err := goforit.RefreshFlags(s.goforit)
 				if err != nil {
-					log.Printf("Error refreshing flags on HUP: %s\n", err)
+					log.Printf("Error refreshing flags on HUP: %s", err)
 				}
 			}
 
@@ -362,7 +362,7 @@ func (s *sequins) remoteRefresh() bool {
 		flagName += "." + s.config.Sharding.ClusterName
 	}
 	if s.goforit != nil && goforit.Enabled(context.Background(), flagName) {
-		log.Printf("Not allowing remote refresh: cluster=%s, flag=%s\n",
+		log.Printf("Not allowing remote refresh: cluster=%q, flag=%q",
 			s.config.Sharding.ClusterName, flagName)
 		if s.stats != nil {
 			s.stats.Count(flagName, 1, []string{}, 1.0)

--- a/sequins.go
+++ b/sequins.go
@@ -375,7 +375,8 @@ func (s *sequins) remoteRefresh() bool {
 
 // Refresh all datasets.
 //
-// An initial load can refrain from checking for new DBs/versions by setting initialLocal.
+// If initialStartup is set to TRUE and remoteRefresh() is disabled,
+// initial loads will refrain from checking for new DBs/versions
 func (s *sequins) refreshAll(initialStartup bool) {
 	s.refreshLock.Lock()
 	defer s.refreshLock.Unlock()

--- a/sequins.go
+++ b/sequins.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/juju/ratelimit"
 	"github.com/nightlyone/lockfile"
 	"github.com/stripe/goforit"
@@ -163,8 +162,13 @@ func (s *sequins) init() error {
 		for range sighups {
 			// Refresh any feature flags on HUP
 			if s.goforit != nil {
-				goforit.RefreshFlags(s.goforit)
+				log.Printf("HUP!\n")
+				err := goforit.RefreshFlags(s.goforit)
+				if err != nil {
+					log.Printf("Error refreshing flags on HUP: %s\n", err)
+				}
 			}
+
 			if s.remoteRefresh() {
 				s.refreshAll(false)
 			}

--- a/sequins.go
+++ b/sequins.go
@@ -160,7 +160,6 @@ func (s *sequins) init() error {
 		for range sighups {
 			// Refresh any feature flags on HUP
 			if s.goforit != nil {
-				log.Printf("HUP!\n")
 				err := goforit.RefreshFlags(s.goforit)
 				if err != nil {
 					log.Printf("Error refreshing flags on HUP: %s\n", err)

--- a/sequins.go
+++ b/sequins.go
@@ -170,12 +170,12 @@ func (s *sequins) init() error {
 	return nil
 }
 
-func (s *sequins) remoteRefresh(cause string) bool {
+func (s *sequins) remoteRefresh(trigger string) bool {
 	flagName := disableRemoteRefreshFlagPrefix + s.config.Sharding.ClusterName
   if s.config.Goforit != nil && goforit.Enabled(flagName) {
     log.Printf("Not allowing remote refresh %s in cluster %s because flag %s is
 			enabled", s.config.Sharding.ShardID, s.config.Sharding.ClusterName, flagName)
-		s.stats.Count(flagName, 1, []string{"cause:" + cause}, 1.0)
+		s.stats.Count(flagName, 1, []string{"trigger:" + trigger}, 1.0)
 		return false
   } else {
 		return true

--- a/sequins.go
+++ b/sequins.go
@@ -381,14 +381,13 @@ func (s *sequins) refreshAll(initialStartup bool) {
 	s.refreshLock.Lock()
 	defer s.refreshLock.Unlock()
 
-	remoteRefresh := s.remoteRefresh()
-	if !remoteRefresh && !initialStartup {
-		return
-	}
-
-	initialLocal := !remoteRefresh && initialStartup
-	if initialLocal {
+	var initialLocal bool
+	if !s.remoteRefresh() {
+		if !initialStartup {
+			return
+		}
 		log.Printf("Kicking off initial local-only refresh")
+		initialLocal = true
 	}
 
 	dbs, err := s.listDBs()

--- a/sequins.go
+++ b/sequins.go
@@ -173,7 +173,7 @@ func (s *sequins) init() error {
 func (s *sequins) remoteRefresh(trigger string) bool {
 	flagName := disableRemoteRefreshFlagPrefix + s.config.Sharding.ClusterName
 	if s.config.Goforit != nil && goforit.Enabled(flagName) {
-		log.Printf("Not allowing remote refresh %s in cluster %s because flag %s is"+
+		log.Printf("Not allowing remote refresh %s in cluster %s because flag %s is "+
 			"enabled", s.config.Sharding.ShardID, s.config.Sharding.ClusterName, flagName)
 		s.stats.Count(flagName, 1, []string{"trigger:" + trigger}, 1.0)
 		return false

--- a/sequins.go
+++ b/sequins.go
@@ -19,9 +19,9 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/juju/ratelimit"
 	"github.com/nightlyone/lockfile"
+	"github.com/stripe/goforit"
 	"github.com/tylerb/graceful"
 
-	"github.com/stripe/goforit"
 	"github.com/stripe/sequins/backend"
 	"github.com/stripe/sequins/sharding"
 	"github.com/stripe/sequins/workqueue"
@@ -128,6 +128,8 @@ func (s *sequins) init() error {
 	if s.config.GoforitFlagJsonPath != nil {
 		log.Printf("Enabling Goforit: GoforitFlagJsonPath=%s", s.GoforitFlagJsonPath)
 		backend := goforit.BackendFromJSONFile(s.config.GoforitFlagJsonPath)
+
+		// TODO(amith): make constant
 		goforit.Init(30*time.Second, backend)
 	}
 
@@ -174,7 +176,7 @@ func (s *sequins) remoteRefresh() bool {
 	if s.config.Sharding.ClusterName != nil {
 		flagName += "." + s.config.Sharding.ClusterName
 	}
-	if s.config.Goforit != nil && goforit.Enabled(flagName) {
+	if s.config.GoforitFlagJsonPath != nil && goforit.Enabled(flagName) {
 		log.Printf("Not allowing remote refresh: cluster=%s, flag=%s\n",
 			s.config.Sharding.ClusterName, flagName)
 		if s.stats != nil {

--- a/sequins.go
+++ b/sequins.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -125,8 +126,8 @@ func (s *sequins) init() error {
 	}
 
 	// Kick off feature flag cache refresh if GoforitFlagJsonPath configured
-	if s.config.GoforitFlagJsonPath != nil {
-		log.Printf("Enabling Goforit: GoforitFlagJsonPath=%s", s.GoforitFlagJsonPath)
+	if s.config.GoforitFlagJsonPath != "" {
+		log.Printf("Enabling Goforit: GoforitFlagJsonPath=%s", s.config.GoforitFlagJsonPath)
 		backend := goforit.BackendFromJSONFile(s.config.GoforitFlagJsonPath)
 
 		// TODO(amith): make constant
@@ -173,10 +174,10 @@ func (s *sequins) init() error {
 
 func (s *sequins) remoteRefresh() bool {
 	flagName := disableRemoteRefreshFlagPrefix
-	if s.config.Sharding.ClusterName != nil {
+	if s.config.Sharding.ClusterName != "" {
 		flagName += "." + s.config.Sharding.ClusterName
 	}
-	if s.config.GoforitFlagJsonPath != nil && goforit.Enabled(flagName) {
+	if s.config.GoforitFlagJsonPath != "" && goforit.Enabled(context.Background(), flagName) {
 		log.Printf("Not allowing remote refresh: cluster=%s, flag=%s\n",
 			s.config.Sharding.ClusterName, flagName)
 		if s.stats != nil {

--- a/sequins_test.go
+++ b/sequins_test.go
@@ -283,7 +283,7 @@ func TestSequinsThreadsafe(t *testing.T) {
 
 	for i := 1; i < 100; i++ {
 		createTestIndex(t, scratch, i)
-		ts.refreshAll()
+		ts.refreshAll(false)
 	}
 	wg.Wait()
 	os.RemoveAll(scratch)

--- a/vendor/github.com/stripe/goforit/Dockerfile
+++ b/vendor/github.com/stripe/goforit/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.7
+MAINTAINER The Stripe Observability Team <support@stripe.com>
+
+RUN mkdir -p /build
+ENV GOPATH=/go
+
+RUN go get -u -v github.com/kardianos/govendor
+
+WORKDIR /go/src/github.com/stripe/goforit
+ADD . /go/src/github.com/stripe/goforit
+
+
+CMD govendor test -v -timeout 10s +local

--- a/vendor/github.com/stripe/goforit/README.md
+++ b/vendor/github.com/stripe/goforit/README.md
@@ -1,0 +1,45 @@
+[![Build Status](https://travis-ci.org/stripe/goforit.svg?branch=master)](https://travis-ci.org/stripe/goforit)
+[![GoDoc](https://godoc.org/github.com/stripe/goforit?status.svg)](http://godoc.org/github.com/stripe/goforit)
+
+goforit is an experimental, quick-and-dirty client library for feature flags in Go.
+
+# Backends
+
+Feature flags can be stored in any desired backend. goforit provides a flatfile implementation out-of-the-box, so feature flags can be defined in a [CSV][CSV] file.
+
+Alternatively, flags can be stored in a key-value store like Consul or Redis.
+
+
+# Usage
+
+Create a CSV file that defines the flag names and sampling rates:
+
+```csv
+go.sun.money,0
+go.moon.mercury,1
+go.stars.money,.5
+```
+
+```go
+func main() {
+	// flags.csv contains comma-separated flag names and sample rates.
+	// See: fixtures/flags_example.csv
+	backend := goforit.BackendFromFile("flags.csv")
+	goforit.Init(30*time.Second, backend)
+
+	if goforit.Enabled("go.sun.mercury") {
+		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
+	}
+
+	if goforit.Enabled("go.stars.money") {
+		fmt.Println("The go.stars.money feature is enabled for 50% of requests")
+	}
+}
+```
+
+
+# Status
+
+goforit is in an experimental state and may introduce breaking changes without notice.
+
+[CSV]: https://github.com/stripe/goforit/blob/master/fixtures/flags_example.csv

--- a/vendor/github.com/stripe/goforit/examples_test.go
+++ b/vendor/github.com/stripe/goforit/examples_test.go
@@ -1,0 +1,28 @@
+package goforit
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+func Example() {
+	ctx := context.Background()
+
+	// flags.csv contains comma-separated flag names and sample rates.
+	// See: fixtures/flags_example.csv
+	backend := BackendFromFile("flags.csv")
+	Init(30*time.Second, backend)
+
+	if Enabled(ctx, "go.sun.mercury") {
+		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
+	}
+	// Same thing.
+	if Enabled(nil, "go.sun.mercury") {
+		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
+	}
+
+	if Enabled(ctx, "go.stars.money") {
+		fmt.Println("The go.stars.money feature is enabled for 50% of requests")
+	}
+}

--- a/vendor/github.com/stripe/goforit/examples_whitebox_test.go
+++ b/vendor/github.com/stripe/goforit/examples_whitebox_test.go
@@ -1,0 +1,30 @@
+package goforit_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/stripe/goforit"
+)
+
+func Example() {
+	ctx := context.Background()
+
+	// flags.csv contains comma-separated flag names and sample rates.
+	// See: fixtures/flags_example.csv
+	backend := goforit.BackendFromFile("flags.csv")
+	goforit.Init(30*time.Second, backend)
+
+	if goforit.Enabled(ctx, "go.sun.mercury") {
+		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
+	}
+	// Same thing.
+	if goforit.Enabled(nil, "go.sun.mercury") {
+		fmt.Println("The go.sun.mercury feature is enabled for 100% of requests")
+	}
+
+	if goforit.Enabled(ctx, "go.stars.money") {
+		fmt.Println("The go.stars.money feature is enabled for 50% of requests")
+	}
+}

--- a/vendor/github.com/stripe/goforit/flags.go
+++ b/vendor/github.com/stripe/goforit/flags.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
+	"github.com/davecgh/go-spew/spew"
 )
 
 const statsdAddress = "127.0.0.1:8200"
@@ -152,8 +153,10 @@ func parseFlagsJSON(r io.Reader) (map[string]Flag, error) {
 	var v JSONFormat
 	err := dec.Decode(&v)
 	if err != nil {
+		fmt.Printf("WTF? %s\n", err)
 		return nil, err
 	}
+	spew.Dump(v.Flags)
 	return flagsToMap(v.Flags), nil
 }
 

--- a/vendor/github.com/stripe/goforit/flags.go
+++ b/vendor/github.com/stripe/goforit/flags.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
-	"github.com/davecgh/go-spew/spew"
 )
 
 const statsdAddress = "127.0.0.1:8200"
@@ -153,10 +152,8 @@ func parseFlagsJSON(r io.Reader) (map[string]Flag, error) {
 	var v JSONFormat
 	err := dec.Decode(&v)
 	if err != nil {
-		fmt.Printf("WTF? %s\n", err)
 		return nil, err
 	}
-	spew.Dump(v.Flags)
 	return flagsToMap(v.Flags), nil
 }
 

--- a/vendor/github.com/stripe/goforit/flags.go
+++ b/vendor/github.com/stripe/goforit/flags.go
@@ -1,0 +1,240 @@
+package goforit
+
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-go/statsd"
+)
+
+const statsdAddress = "127.0.0.1:8200"
+
+var stats *statsd.Client
+
+func init() {
+	stats, _ = statsd.New(statsdAddress)
+}
+
+const DefaultInterval = 30 * time.Second
+
+type Backend interface {
+	Refresh() (map[string]Flag, error)
+}
+
+type csvFileBackend struct {
+	filename string
+}
+
+type jsonFileBackend struct {
+	filename string
+}
+
+func readFile(file string, backend string, parse func(io.Reader) (map[string]Flag, error)) (map[string]Flag, error) {
+	var checkStatus statsd.ServiceCheckStatus
+	defer func() {
+		stats.SimpleServiceCheck("goforit.refreshFlags."+backend+"FileBackend.present", checkStatus)
+	}()
+	f, err := os.Open(file)
+	if err != nil {
+		checkStatus = statsd.Warn
+		return nil, err
+	}
+	defer f.Close()
+	return parse(f)
+}
+
+func (b jsonFileBackend) Refresh() (map[string]Flag, error) {
+	return readFile(b.filename, "json", parseFlagsJSON)
+}
+
+func (b csvFileBackend) Refresh() (map[string]Flag, error) {
+	return readFile(b.filename, "csv", parseFlagsCSV)
+}
+
+type Flag struct {
+	Name string
+	Rate float64
+}
+
+type JSONFormat struct {
+	Flags []Flag `json:"flags"`
+}
+
+var flags = map[string]Flag{}
+var flagsMtx = sync.RWMutex{}
+
+// Enabled returns a boolean indicating
+// whether or not the flag should be considered
+// enabled. It returns false if no flag with the specified
+// name is found
+func Enabled(ctx context.Context, name string) (enabled bool) {
+	defer func() {
+		var gauge float64
+		if enabled {
+			gauge = 1
+		}
+		stats.Gauge("goforit.flags.enabled", gauge, []string{fmt.Sprintf("flag:%s", name)}, .1)
+	}()
+
+	// Check for an override.
+	if ctx != nil {
+		if ov, ok := ctx.Value(overrideContextKey).(overrides); ok {
+			if enabled, ok = ov[name]; ok {
+				return
+			}
+		}
+	}
+
+	flagsMtx.RLock()
+	defer flagsMtx.RUnlock()
+	if flags == nil {
+		enabled = false
+		return
+	}
+	flag := flags[name]
+
+	// equality should be strict
+	// because Float64() can return 0
+	if f := rand.Float64(); f < flag.Rate {
+		enabled = true
+		return
+	}
+	enabled = false
+	return
+}
+
+func flagsToMap(flags []Flag) map[string]Flag {
+	flagsMap := map[string]Flag{}
+	for _, flag := range flags {
+		flagsMap[flag.Name] = Flag{Name: flag.Name, Rate: flag.Rate}
+	}
+	return flagsMap
+}
+
+func parseFlagsCSV(r io.Reader) (map[string]Flag, error) {
+	// every row is guaranteed to have 2 fields
+	const FieldsPerRecord = 2
+
+	cr := csv.NewReader(r)
+	cr.FieldsPerRecord = FieldsPerRecord
+	cr.TrimLeadingSpace = true
+
+	rows, err := cr.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+
+	flags := map[string]Flag{}
+	for _, row := range rows {
+		name := row[0]
+
+		rate, err := strconv.ParseFloat(row[1], 64)
+		if err != nil {
+			// TODO also track somehow
+			rate = 0
+		}
+
+		flags[name] = Flag{Name: name, Rate: rate}
+	}
+	return flags, nil
+}
+
+func parseFlagsJSON(r io.Reader) (map[string]Flag, error) {
+	dec := json.NewDecoder(r)
+	var v JSONFormat
+	err := dec.Decode(&v)
+	if err != nil {
+		return nil, err
+	}
+	return flagsToMap(v.Flags), nil
+}
+
+// BackendFromFile is a helper function that creates a valid
+// FlagBackend from a CSV file containing the feature flag values.
+// If the same flag is defined multiple times in the same file,
+// the last result will be used.
+func BackendFromFile(filename string) Backend {
+	return csvFileBackend{filename}
+}
+
+// BackendFromJSONFile creates a backend powered by JSON file
+// instead of CSV
+func BackendFromJSONFile(filename string) Backend {
+	return jsonFileBackend{filename}
+}
+
+// RefreshFlags will use the provided thunk function to
+// fetch all feature flags and update the internal cache.
+// The thunk provided can use a variety of mechanisms for
+// querying the flag values, such as a local file or
+// Consul key/value storage.
+func RefreshFlags(backend Backend) error {
+
+	refreshedFlags, err := backend.Refresh()
+	if err != nil {
+		return err
+	}
+
+	fmap := map[string]Flag{}
+	for _, flag := range refreshedFlags {
+		fmap[flag.Name] = flag
+	}
+
+	// update the package-level flags
+	// which are protected by the mutex
+	flagsMtx.Lock()
+	flags = fmap
+	flagsMtx.Unlock()
+
+	return nil
+}
+
+// Init initializes the flag backend, using the provided refresh function
+// to update the internal cache of flags periodically, at the specified interval.
+// When the Ticker returned by Init is closed, updates will stop.
+func Init(interval time.Duration, backend Backend) *time.Ticker {
+
+	ticker := time.NewTicker(interval)
+	err := RefreshFlags(backend)
+	if err != nil {
+		stats.Count("goforit.refreshFlags.errors", 1, nil, 1)
+	}
+
+	go func() {
+		for _ = range ticker.C {
+			err := RefreshFlags(backend)
+			if err != nil {
+				stats.Count("goforit.refreshFlags.errors", 1, nil, 1)
+			}
+		}
+	}()
+	return ticker
+}
+
+// A unique context key for overrides
+type overrideContextKeyType struct{}
+
+var overrideContextKey = overrideContextKeyType{}
+
+type overrides map[string]bool
+
+// Override allows overriding the value of a goforit flag within a context.
+// This is mainly useful for tests.
+func Override(ctx context.Context, name string, value bool) context.Context {
+	ov := overrides{}
+	if old, ok := ctx.Value(overrideContextKey).(overrides); ok {
+		for k, v := range old {
+			ov[k] = v
+		}
+	}
+	ov[name] = value
+	return context.WithValue(ctx, overrideContextKey, ov)
+}

--- a/vendor/github.com/stripe/goforit/flags_test.go
+++ b/vendor/github.com/stripe/goforit/flags_test.go
@@ -1,0 +1,291 @@
+package goforit
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// arbitrary but fixed for reproducible testing
+const seed = 5194304667978865136
+
+const ε = .02
+
+func Reset() {
+	flags = map[string]Flag{}
+	flagsMtx = sync.RWMutex{}
+}
+
+func TestParseFlagsCSV(t *testing.T) {
+	filename := filepath.Join("fixtures", "flags_example.csv")
+
+	type testcase struct {
+		Name     string
+		Filename string
+		Expected []Flag
+	}
+
+	cases := []testcase{
+		{
+			Name:     "BasicExample",
+			Filename: filepath.Join("fixtures", "flags_example.csv"),
+			Expected: []Flag{
+				{
+					"go.sun.money",
+					0,
+				},
+				{
+					"go.moon.mercury",
+					1,
+				},
+				{
+					"go.stars.money",
+					0.5,
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			f, err := os.Open(filename)
+			assert.NoError(t, err)
+			defer f.Close()
+
+			flags, err := parseFlagsCSV(f)
+
+			assertFlagsEqual(t, flagsToMap(tc.Expected), flags)
+		})
+	}
+}
+
+func TestParseFlagsJSON(t *testing.T) {
+	filename := filepath.Join("fixtures", "flags_example.json")
+
+	type testcase struct {
+		Name     string
+		Filename string
+		Expected []Flag
+	}
+
+	cases := []testcase{
+		{
+			Name:     "BasicExample",
+			Filename: filepath.Join("fixtures", "flags_example.json"),
+			Expected: []Flag{
+				{
+					"sequins.prevent_download",
+					0,
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			f, err := os.Open(filename)
+			assert.NoError(t, err)
+			defer f.Close()
+
+			flags, err := parseFlagsJSON(f)
+
+			assertFlagsEqual(t, flagsToMap(tc.Expected), flags)
+		})
+	}
+}
+
+func TestEnabled(t *testing.T) {
+	const iterations = 100000
+
+	Reset()
+	backend := BackendFromFile(filepath.Join("fixtures", "flags_example.csv"))
+	ticker := Init(DefaultInterval, backend)
+	defer ticker.Stop()
+
+	assert.False(t, Enabled(context.Background(), "go.sun.money"))
+	assert.True(t, Enabled(context.Background(), "go.moon.mercury"))
+
+	// nil is equivalent to empty context
+	assert.False(t, Enabled(nil, "go.sun.money"))
+	assert.True(t, Enabled(nil, "go.moon.mercury"))
+
+	count := 0
+	for i := 0; i < iterations; i++ {
+		if Enabled(context.Background(), "go.stars.money") {
+			count++
+		}
+	}
+	actualRate := float64(count) / float64(iterations)
+
+	assert.InEpsilon(t, 0.5, actualRate, ε)
+}
+
+// dummyBackend lets us test the RefreshFlags
+// by returning the flags only the second time the Refresh
+// method is called
+type dummyBackend struct {
+	// tally how many times Refresh() has been called
+	refreshedCount int
+}
+
+func (b *dummyBackend) Refresh() (map[string]Flag, error) {
+	defer func() {
+		b.refreshedCount++
+	}()
+
+	if b.refreshedCount == 0 {
+		return map[string]Flag{}, nil
+	}
+
+	f, err := os.Open(filepath.Join("fixtures", "flags_example.csv"))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return parseFlagsCSV(f)
+}
+
+func TestRefresh(t *testing.T) {
+	Reset()
+	backend := &dummyBackend{}
+
+	assert.False(t, Enabled(context.Background(), "go.sun.money"))
+	assert.False(t, Enabled(context.Background(), "go.moon.mercury"))
+
+	ticker := Init(10*time.Millisecond, backend)
+	defer ticker.Stop()
+
+	// ensure refresh runs twice to avoid race conditions
+	// in which the Refresh method returns but the assertions get called
+	// before the flags are actually updated
+	for backend.refreshedCount < 2 {
+		<-time.After(10 * time.Millisecond)
+	}
+
+	assert.False(t, Enabled(context.Background(), "go.sun.money"))
+	assert.True(t, Enabled(context.Background(), "go.moon.mercury"))
+}
+
+func TestMultipleDefinitions(t *testing.T) {
+	const repeatedFlag = "go.sun.money"
+	const lastValue = 0.7
+	Reset()
+
+	backend := BackendFromFile(filepath.Join("fixtures", "flags_multiple_definitions.csv"))
+	RefreshFlags(backend)
+
+	flag := flags[repeatedFlag]
+	assert.Equal(t, flag, Flag{repeatedFlag, lastValue})
+
+}
+
+// BenchmarkEnabled runs a benchmark for a feature flag
+// that is enabled for 50% of operations.
+func BenchmarkEnabled(b *testing.B) {
+	Reset()
+	backend := BackendFromFile(filepath.Join("fixtures", "flags_example.csv"))
+	ticker := Init(DefaultInterval, backend)
+	defer ticker.Stop()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = Enabled(context.Background(), "go.stars.money")
+	}
+}
+
+// assertFlagsEqual is a helper function for asserting
+// that two maps of flags are equal
+func assertFlagsEqual(t *testing.T, expected, actual map[string]Flag) {
+	assert.Equal(t, len(expected), len(actual))
+
+	for k, v := range expected {
+		assert.Equal(t, v, actual[k])
+	}
+}
+
+func TestOverride(t *testing.T) {
+	Reset()
+
+	backend := BackendFromFile(filepath.Join("fixtures", "flags_example.csv"))
+	ticker := Init(DefaultInterval, backend)
+	defer ticker.Stop()
+	RefreshFlags(backend)
+
+	// Empty context gets values from backend.
+	assert.False(t, Enabled(context.Background(), "go.sun.money"))
+	assert.True(t, Enabled(context.Background(), "go.moon.mercury"))
+	assert.False(t, Enabled(context.Background(), "go.extra"))
+
+	// Nil is equivalent to empty context.
+	assert.False(t, Enabled(nil, "go.sun.money"))
+	assert.True(t, Enabled(nil, "go.moon.mercury"))
+	assert.False(t, Enabled(nil, "go.extra"))
+
+	// Can override to true in context.
+	ctx := context.Background()
+	ctx = Override(ctx, "go.sun.money", true)
+	assert.True(t, Enabled(ctx, "go.sun.money"))
+	assert.True(t, Enabled(ctx, "go.moon.mercury"))
+	assert.False(t, Enabled(ctx, "go.extra"))
+
+	// Can override to false.
+	ctx = Override(ctx, "go.moon.mercury", false)
+	assert.True(t, Enabled(ctx, "go.sun.money"))
+	assert.False(t, Enabled(ctx, "go.moon.mercury"))
+	assert.False(t, Enabled(ctx, "go.extra"))
+
+	// Can override brand new flag.
+	ctx = Override(ctx, "go.extra", true)
+	assert.True(t, Enabled(ctx, "go.sun.money"))
+	assert.False(t, Enabled(ctx, "go.moon.mercury"))
+	assert.True(t, Enabled(ctx, "go.extra"))
+
+	// Can override an override.
+	ctx = Override(ctx, "go.extra", false)
+	assert.True(t, Enabled(ctx, "go.sun.money"))
+	assert.False(t, Enabled(ctx, "go.moon.mercury"))
+	assert.False(t, Enabled(ctx, "go.extra"))
+
+	// Separate contexts don't interfere with each other.
+	// This allows parallel tests that use feature flags.
+	ctx2 := Override(context.Background(), "go.extra", true)
+	assert.True(t, Enabled(ctx, "go.sun.money"))
+	assert.False(t, Enabled(ctx, "go.moon.mercury"))
+	assert.False(t, Enabled(ctx, "go.extra"))
+	assert.False(t, Enabled(ctx2, "go.sun.money"))
+	assert.True(t, Enabled(ctx2, "go.moon.mercury"))
+	assert.True(t, Enabled(ctx2, "go.extra"))
+
+	// Overrides apply to child contexts.
+	child := context.WithValue(ctx, "foo", "bar")
+	assert.True(t, Enabled(child, "go.sun.money"))
+	assert.False(t, Enabled(child, "go.moon.mercury"))
+	assert.False(t, Enabled(child, "go.extra"))
+
+	// Changes to child contexts don't affect parents.
+	child = Override(child, "go.moon.mercury", true)
+	assert.True(t, Enabled(child, "go.sun.money"))
+	assert.True(t, Enabled(child, "go.moon.mercury"))
+	assert.False(t, Enabled(child, "go.extra"))
+	assert.True(t, Enabled(ctx, "go.sun.money"))
+	assert.False(t, Enabled(ctx, "go.moon.mercury"))
+	assert.False(t, Enabled(ctx, "go.extra"))
+}
+
+func TestOverrideWithoutInit(t *testing.T) {
+	Reset()
+
+	// Everything is false by default.
+	assert.False(t, Enabled(context.Background(), "go.sun.money"))
+	assert.False(t, Enabled(context.Background(), "go.moon.mercury"))
+
+	// Can override.
+	ctx := Override(context.Background(), "go.sun.money", true)
+	assert.True(t, Enabled(ctx, "go.sun.money"))
+	assert.False(t, Enabled(ctx, "go.moon.mercury"))
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1625,6 +1625,12 @@
 			"revisionTime": "2018-01-30T19:37:22Z"
 		},
 		{
+			"checksumSHA1": "yplPuRAwWroEt3ZCrUzpH/Wle2U=",
+			"path": "github.com/stripe/goforit",
+			"revision": "13c1dbb8ac77804cccf5dd67fc8ebaad639bb2e1",
+			"revisionTime": "2018-02-22T19:01:40Z"
+		},
+		{
 			"checksumSHA1": "dcOJtT2YpM6/qNQUa+IGGjFUy0k=",
 			"path": "golang.org/x/net/html",
 			"revision": "ab5485076ff3407ad2d02db054635913f017b0ed",


### PR DESCRIPTION
This lets Sequins start up in a mode where it only checks local disk for versions, rather than the network (mostly). It should enable rolling sequins with checking-for-new-versions off, and hence our feature flags use-case.

cc @scottjab-stripe @amith-stripe
