### PR TITLE
Serialize cleaning up znodes for old db versions and avoid a race condition

### DIFF
--- a/sequins.go
+++ b/sequins.go
@@ -257,8 +257,6 @@ func (s *sequins) initCluster() error {
 		log.Fatal("Dying due to ZK flapping")
 	}()
 
-	go zkWatcher.TriggerCleanup()
-
 	hostname := s.config.Sharding.AdvertisedHostname
 	if hostname == "" {
 		hostname, err = os.Hostname()
@@ -450,7 +448,7 @@ func (s *sequins) refreshAll(initialStartup bool) {
 
 	// Cleanup any zkNodes for deleted versions and dbs.
 	if s.zkWatcher != nil {
-		s.zkWatcher.TriggerCleanup()
+		go s.zkWatcher.TriggerCleanup()
 	}
 }
 


### PR DESCRIPTION
We found in the sequins log most zookeeper errors happen because of 'node does not exist'. TriggerCleanup() is used to cleanup the old znodes for db versions that sequins nodes are no longer serving. But it takes a naive approach to deletes znodes. It just traverses the directory tree and delete the non-ephemeral znodes that can be deleted.  So there is a race condition when a znode for a new db version was just created and no partition of the db version has been downloaded by any sequins node (therefore no ephemeral nodes created in the db version znode). TriggerCleanup() can delete the db version znode right after it is created, causing all sequins nodes watching the db version znode to get 'node does not exist' error and they have to reconnect to zookeeper. The reconnecting to zookeeper is very expensive in sequins. It also causes unnecessary load on zookeeper server. We should avoid this race condition. 

There is another problem with TriggerCleanup(). It launches a large number of goroutines to attempt to delete znodes in parallel. We found this behavior causes scheduling delay for other goroutines. It causes the 504 errors because the goroutines serving http requests are timed out. We also need to change this behavior.  

r? @bartle-stripe @vasi-stripe  