### PR TITLE
Add request logging via feature flag

### DIFF
--- a/config.go
+++ b/config.go
@@ -71,10 +71,11 @@ type zkConfig struct {
 }
 
 type debugConfig struct {
-	Bind       string `toml:"bind"`
-	Expvars    bool   `toml:"expvars"`
-	Pprof      bool   `toml:"pprof"`
-	RequestLog string `toml:"request_log"`
+	Bind             string `toml:"bind"`
+	Expvars          bool   `toml:"expvars"`
+	Pprof            bool   `toml:"pprof"`
+	RequestLogEnable bool   `toml:"request_log_enable"`
+	RequestLogFile   string `toml:"request_log_file"`
 }
 
 // testConfig has some options used in functional tests to slow sequins down
@@ -132,10 +133,11 @@ func defaultConfig() sequinsConfig {
 			SessionTimeout: duration{10 * time.Second},
 		},
 		Debug: debugConfig{
-			Bind:       "",
-			Expvars:    true,
-			Pprof:      false,
-			RequestLog: "",
+			Bind:             "",
+			Expvars:          true,
+			Pprof:            false,
+			RequestLogEnable: false,
+			RequestLogFile:   "",
 		},
 		Test: testConfig{
 			UpgradeDelay:         duration{time.Duration(0)},

--- a/debug_test.go
+++ b/debug_test.go
@@ -104,7 +104,8 @@ func TestRequestLog(t *testing.T) {
 	config.Bind = "localhost:9599"
 	config.LocalStore = localStore
 	config.MaxParallelLoads = 1
-	config.Debug.RequestLog = requestLog.Name()
+	config.Debug.RequestLogEnable = true
+	config.Debug.RequestLogFile = requestLog.Name()
 	s := newSequins(localBackend, config)
 	require.NoError(t, s.init())
 	waitForDBs(t, s)

--- a/sequins.conf.example
+++ b/sequins.conf.example
@@ -174,5 +174,9 @@ source = "hdfs://namenode:8020/path/to/sequins"
 # pprof = false
 # If set, this adds the default pprof handlers to the debug HTTP server.
 
-# request_log = "/var/log/sequins-requests.log"
-# Unset by default. If set, requests will be logged to the provided file.
+# request_log_enable = false
+# If set, this enables request logging. Must also set request_log_file.
+
+# request_log_file = "/var/log/sequins-requests.log"
+# Unset by default. If set, this will be the destination for any request logging.
+# Request logging can then be enabled with either request_log, or a feature flag.


### PR DESCRIPTION
We have request logging, but deploying it is a real pain in the butt on a large cluster.

Use a feature flag instead!