### PR TITLE
Add support to log requests to stdout instead of a different file.

### DIFF
--- a/config.go
+++ b/config.go
@@ -137,7 +137,7 @@ func defaultConfig() sequinsConfig {
 			Expvars:          true,
 			Pprof:            false,
 			RequestLogEnable: false,
-			RequestLogFile:   "",
+			RequestLogFile:   "stdout",
 		},
 		Test: testConfig{
 			UpgradeDelay:         duration{time.Duration(0)},

--- a/debug_test.go
+++ b/debug_test.go
@@ -61,7 +61,7 @@ func readRequestLog(logPath string) (requestLogs, error) {
 	for {
 		var datePart, timePart string
 		var log requestLog
-		_, err := fmt.Fscanf(f, "%s %s %q %d\n", &datePart, &timePart, &log.path, &log.status)
+		_, err := fmt.Fscanf(f, "%s %s CANONICAL-SEQUINS-REQUEST-LINE %q %d\n", &datePart, &timePart, &log.path, &log.status)
 		if err == io.EOF {
 			return logs, nil
 		}


### PR DESCRIPTION
Sometimes you don't want to log requests to a different log file.


r? @vasi-stripe 

cc @stripe/storage 