### PR TITLE
Enable build egress proxying

### DIFF
--- a/stripe-build.yaml
+++ b/stripe-build.yaml
@@ -1,0 +1,7 @@
+# See go/stripe-build for more information about customizing this file
+---
+henson_tarball:
+  docker: {}
+network:
+  restrict_network: true
+  http_proxy_report_only: true


### PR DESCRIPTION
This PR forces all network traffic during the Jenkins build to go through a local sidecar
proxy on the Jenkins instance. This will allow us to properly route internet-bound traffic
through a smokescreen proxy instance and then prevent jenkins workers from talking directly
to the internet. See http://go.corp.stripe.com/stripe-build-egress-restriction for more information.

Self-lgtming this PR per discussion with @areitz that he will review one of these
autogenerated PRs and the generation code rather than each PR individually.

r? @andrew
cc @areitz
