### PR TITLE
Update the zookeeper url to retrieve the package over TLS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: go
 go: 1.8.3
 sudo: false
 before_install:
-- wget http://archive.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz
+- wget https://archive.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz
 - tar -zxvf zookeeper*tar.gz
 - export NN_PORT=9000
 - export HADOOP_NAMENODE="localhost:$NN_PORT"


### PR DESCRIPTION
Change the apache.org url in the travis config so that it pulls in zookeeper over HTTPS.